### PR TITLE
feat: support split sizing with cells suffix

### DIFF
--- a/examples/basic-layout.yml
+++ b/examples/basic-layout.yml
@@ -10,7 +10,7 @@ presets:
     description: "Development environment (Editor + Server + Logs)"
     layout:
       type: horizontal
-      ratio: [60, 40]
+      ratio: ["90c", 2]  # fixed left pane + weighted right pane
       panes:
         - command: nvim
           name: Editor

--- a/src/backends/pane-tracking.ts
+++ b/src/backends/pane-tracking.ts
@@ -1,0 +1,34 @@
+export type PaneDimensions = {
+  readonly cols: number
+  readonly rows: number
+}
+
+export const updatePaneSizes = ({
+  paneSizes,
+  targetPaneId,
+  createdPaneId,
+  orientation,
+  targetCells,
+  createdCells,
+}: {
+  readonly paneSizes: Map<string, PaneDimensions>
+  readonly targetPaneId: string
+  readonly createdPaneId: string
+  readonly orientation: "horizontal" | "vertical"
+  readonly targetCells: number
+  readonly createdCells: number
+}): void => {
+  const base = paneSizes.get(targetPaneId)
+  if (base === undefined) {
+    return
+  }
+
+  if (orientation === "horizontal") {
+    paneSizes.set(targetPaneId, { cols: targetCells, rows: base.rows })
+    paneSizes.set(createdPaneId, { cols: createdCells, rows: base.rows })
+    return
+  }
+
+  paneSizes.set(targetPaneId, { cols: base.cols, rows: targetCells })
+  paneSizes.set(createdPaneId, { cols: base.cols, rows: createdCells })
+}

--- a/src/backends/tmux/backend.ts
+++ b/src/backends/tmux/backend.ts
@@ -1,10 +1,9 @@
+import { execFileSync } from "node:child_process"
 import { createTmuxExecutor } from "./executor"
 import type { CommandStep, PlanEmission } from "../../core/emitter"
+import { isCoreError } from "../../core/errors"
 import { executePlan } from "../../executor/plan-runner"
-import {
-  resolveSplitOrientation as resolveSplitOrientationFromStep,
-  resolveSplitPercentage as resolveSplitPercentageFromStep,
-} from "../../executor/split-step"
+import { resolveSplitOrientation as resolveSplitOrientationFromStep, resolveSplitSize } from "../../executor/split-step"
 import { resolveRequiredStepTargetPaneId } from "../../executor/step-target"
 import { createUnsupportedStepKindError } from "../../executor/unsupported-step-kind"
 import type {
@@ -14,6 +13,14 @@ import type {
   TerminalBackend,
   TmuxTerminalBackendContext,
 } from "../../executor/terminal-backend"
+import { ErrorCodes } from "../../utils/errors"
+
+type PaneDimensions = {
+  readonly cols: number
+  readonly rows: number
+}
+
+const TMUX_VERSION_REGEX = /^tmux\s+(.+)$/
 
 export const createTmuxBackend = (context: TmuxTerminalBackendContext): TerminalBackend => {
   const tmuxExecutor = createTmuxExecutor({
@@ -22,11 +29,26 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
     dryRun: context.dryRun,
   })
 
+  let detectedVersion: string | undefined
+
   const buildDryRunSteps = (emission: PlanEmission): DryRunStep[] => {
+    const paneSizes = new Map<string, PaneDimensions>()
+    const initialPane = emission.summary.initialPaneId
+    const initialPaneSize = resolveInitialTmuxPaneSize()
+    if (typeof initialPaneSize !== "undefined") {
+      paneSizes.set(initialPane, initialPaneSize)
+    }
+
     return emission.steps.map((step) => ({
       backend: "tmux" as const,
       summary: step.summary,
-      command: tmuxExecutor.getCommandString(buildTmuxCommand(step)),
+      command: tmuxExecutor.getCommandString(
+        buildTmuxCommand({
+          step,
+          paneSizes,
+          detectedVersion,
+        }),
+      ),
     }))
   }
 
@@ -35,6 +57,7 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
       return
     }
     await tmuxExecutor.verifyTmuxEnvironment()
+    detectedVersion = await detectTmuxVersion(tmuxExecutor)
   }
 
   const applyPlan = async ({ emission, windowMode, windowName }: ApplyPlanParameters): Promise<ApplyPlanResult> => {
@@ -44,6 +67,7 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
       windowMode,
       windowName,
       onConfirmKill: context.prompt,
+      detectedVersion,
     })
 
     return {
@@ -59,12 +83,74 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
   }
 }
 
-const buildTmuxCommand = (step: CommandStep): string[] => {
+const buildTmuxCommand = ({
+  step,
+  paneSizes,
+  detectedVersion,
+}: {
+  readonly step: CommandStep
+  readonly paneSizes: Map<string, PaneDimensions>
+  readonly detectedVersion?: string
+}): string[] => {
   if (step.kind === "split") {
     const target = resolveRequiredStepTargetPaneId(step)
-    const direction = resolveSplitOrientationFromStep(step) === "horizontal" ? "-h" : "-v"
-    const percent = resolveSplitPercentageFromStep(step)
-    return ["split-window", direction, "-t", target, "-p", percent]
+    const orientation = resolveSplitOrientationFromStep(step)
+    const direction = orientation === "horizontal" ? "-h" : "-v"
+
+    if (step.splitSizing?.mode === "dynamic-cells") {
+      const paneSize = paneSizes.get(target)
+      if (paneSize !== undefined) {
+        const paneCells = orientation === "horizontal" ? paneSize.cols : paneSize.rows
+
+        try {
+          const splitSize = resolveSplitSize(step, {
+            paneCells,
+            paneId: target,
+            detectedVersion,
+            rawPaneRecord: {
+              backend: "tmux",
+              paneId: target,
+              sourceFormat: "tmux-format",
+              size: {
+                cols: paneSize.cols,
+                rows: paneSize.rows,
+              },
+            },
+          })
+
+          if (splitSize.mode === "cells") {
+            if (typeof step.createdPaneId === "string" && step.createdPaneId.length > 0) {
+              updatePaneSizes({
+                paneSizes,
+                targetPaneId: target,
+                createdPaneId: step.createdPaneId,
+                orientation,
+                targetCells: splitSize.targetCells,
+                createdCells: splitSize.createdCells,
+              })
+            }
+            return ["split-window", direction, "-t", target, "-l", splitSize.cells]
+          }
+        } catch (error) {
+          if (isCoreError(error) && error.code === ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED) {
+            // dry-run intentionally falls back to a placeholder when pane size cannot be resolved
+          } else {
+            throw error
+          }
+        }
+      }
+
+      return ["split-window", direction, "-t", target, "-l", "<dynamic>"]
+    }
+
+    const splitSize = resolveSplitSize(step, {
+      paneId: target,
+      detectedVersion,
+    })
+    if (splitSize.mode !== "percent") {
+      throw createUnsupportedStepKindError(step)
+    }
+    return ["split-window", direction, "-t", target, "-p", splitSize.percentage]
   }
 
   if (step.kind === "focus") {
@@ -73,4 +159,77 @@ const buildTmuxCommand = (step: CommandStep): string[] => {
   }
 
   throw createUnsupportedStepKindError(step)
+}
+
+const updatePaneSizes = ({
+  paneSizes,
+  targetPaneId,
+  createdPaneId,
+  orientation,
+  targetCells,
+  createdCells,
+}: {
+  readonly paneSizes: Map<string, PaneDimensions>
+  readonly targetPaneId: string
+  readonly createdPaneId: string
+  readonly orientation: "horizontal" | "vertical"
+  readonly targetCells: number
+  readonly createdCells: number
+}): void => {
+  const base = paneSizes.get(targetPaneId)
+  if (base === undefined) {
+    return
+  }
+
+  if (orientation === "horizontal") {
+    paneSizes.set(targetPaneId, { cols: targetCells, rows: base.rows })
+    paneSizes.set(createdPaneId, { cols: createdCells, rows: base.rows })
+    return
+  }
+
+  paneSizes.set(targetPaneId, { cols: base.cols, rows: targetCells })
+  paneSizes.set(createdPaneId, { cols: base.cols, rows: createdCells })
+}
+
+const detectTmuxVersion = async (tmuxExecutor: ReturnType<typeof createTmuxExecutor>): Promise<string | undefined> => {
+  try {
+    const raw = await tmuxExecutor.execute(["-V"])
+    const match = raw.trim().match(TMUX_VERSION_REGEX)
+    return match?.[1]?.trim()
+  } catch {
+    return undefined
+  }
+}
+
+const resolveInitialTmuxPaneSize = (): PaneDimensions | undefined => {
+  const tmuxPane = process.env.TMUX_PANE
+  const tmuxSession = process.env.TMUX
+  if (
+    typeof tmuxSession !== "string" ||
+    tmuxSession.length === 0 ||
+    typeof tmuxPane !== "string" ||
+    tmuxPane.length === 0
+  ) {
+    return undefined
+  }
+
+  try {
+    const colsRaw = execFileSync("tmux", ["display-message", "-p", "-t", tmuxPane, "#{pane_width}"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim()
+    const rowsRaw = execFileSync("tmux", ["display-message", "-p", "-t", tmuxPane, "#{pane_height}"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim()
+
+    const cols = Number.parseInt(colsRaw, 10)
+    const rows = Number.parseInt(rowsRaw, 10)
+    if (!Number.isInteger(cols) || cols <= 0 || !Number.isInteger(rows) || rows <= 0) {
+      return undefined
+    }
+    return { cols, rows }
+  } catch {
+    return undefined
+  }
 }

--- a/src/backends/wezterm/backend.ts
+++ b/src/backends/wezterm/backend.ts
@@ -3,6 +3,7 @@ import { createCoreError } from "../../core/errors"
 import type {
   ApplyPlanParameters,
   ApplyPlanResult,
+  DryRunStep,
   TerminalBackend,
   WeztermTerminalBackendContext,
 } from "../../executor/terminal-backend"
@@ -10,9 +11,11 @@ import { ErrorCodes } from "../../utils/errors"
 import { listWeztermWindows, runWeztermCli, verifyWeztermAvailability, type WeztermListResult } from "./cli"
 import { buildDryRunSteps } from "./dry-run"
 import { findWorkspaceForPane, resolveInitialPane } from "./layout-resolution"
+import { parseWeztermListResult } from "./list-parser"
 import { registerPaneWithAncestors } from "./pane-map"
 import { applyFocusStep, applySplitStep, applyTerminalCommands } from "./step-execution"
 import type { ExecuteWeztermCommand, PaneMap } from "./shared"
+import { execFileSync } from "node:child_process"
 
 const ensureVirtualPaneId = (emission: PlanEmission): string => {
   const { initialPaneId } = emission.summary
@@ -27,6 +30,8 @@ const ensureVirtualPaneId = (emission: PlanEmission): string => {
 }
 
 export const createWeztermBackend = (context: WeztermTerminalBackendContext): TerminalBackend => {
+  let detectedVersion: string | undefined
+
   const formatCommand = (args: ReadonlyArray<string>): string => {
     return `wezterm cli ${args.join(" ")}`
   }
@@ -64,7 +69,8 @@ export const createWeztermBackend = (context: WeztermTerminalBackendContext): Te
     if (context.dryRun) {
       return
     }
-    await verifyWeztermAvailability()
+    const verification = await verifyWeztermAvailability()
+    detectedVersion = verification.version
   }
 
   const applyPlan = async ({ emission, windowMode }: ApplyPlanParameters): Promise<ApplyPlanResult> => {
@@ -112,6 +118,7 @@ export const createWeztermBackend = (context: WeztermTerminalBackendContext): Te
           runCommand,
           listWindows,
           logPaneMapping,
+          detectedVersion,
         })
         executedSteps += 1
       } else if (step.kind === "focus") {
@@ -149,6 +156,49 @@ export const createWeztermBackend = (context: WeztermTerminalBackendContext): Te
   return {
     verifyEnvironment,
     applyPlan,
-    getDryRunSteps: buildDryRunSteps,
+    getDryRunSteps: (emission: PlanEmission): DryRunStep[] => {
+      const actualPaneId =
+        typeof context.paneId === "string" && context.paneId.length > 0 ? context.paneId : process.env.WEZTERM_PANE
+      const initialPaneSize = resolveInitialWeztermPaneSize(actualPaneId)
+      return buildDryRunSteps(emission, {
+        initialPaneId: emission.summary.initialPaneId,
+        initialPaneSize,
+        detectedVersion,
+      })
+    },
+  }
+}
+
+const resolveInitialWeztermPaneSize = (
+  paneId: string | undefined,
+): { readonly cols: number; readonly rows: number } | undefined => {
+  if (typeof paneId !== "string" || paneId.length === 0) {
+    return undefined
+  }
+
+  try {
+    const stdout = execFileSync("wezterm", ["cli", "list", "--format", "json"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    const parsed = parseWeztermListResult(stdout)
+    if (parsed === undefined) {
+      return undefined
+    }
+    for (const window of parsed.windows) {
+      for (const tab of window.tabs) {
+        for (const pane of tab.panes) {
+          if (pane.paneId === paneId) {
+            if (typeof pane.size?.cols === "number" && typeof pane.size?.rows === "number") {
+              return { cols: pane.size.cols, rows: pane.size.rows }
+            }
+            return undefined
+          }
+        }
+      }
+    }
+    return undefined
+  } catch {
+    return undefined
   }
 }

--- a/src/backends/wezterm/cli.test.ts
+++ b/src/backends/wezterm/cli.test.ts
@@ -61,7 +61,7 @@ describe("runWeztermCli", () => {
 
     const result = await listWeztermWindows()
 
-    expect(result.windows).toEqual([
+    expect(result.windows).toMatchObject([
       {
         windowId: "5",
         isActive: true,
@@ -71,14 +71,22 @@ describe("runWeztermCli", () => {
             tabId: "7",
             isActive: true,
             panes: [
-              { paneId: "10", isActive: true },
-              { paneId: "11", isActive: false },
+              {
+                paneId: "10",
+                isActive: true,
+                rawPaneRecord: { sourceFormat: "wezterm-array" },
+              },
+              {
+                paneId: "11",
+                isActive: false,
+                rawPaneRecord: { sourceFormat: "wezterm-array" },
+              },
             ],
           },
           {
             tabId: "8",
             isActive: false,
-            panes: [{ paneId: "12", isActive: false }],
+            panes: [{ paneId: "12", isActive: false, rawPaneRecord: { sourceFormat: "wezterm-array" } }],
           },
         ],
       },
@@ -90,7 +98,7 @@ describe("runWeztermCli", () => {
           {
             tabId: "9",
             isActive: true,
-            panes: [{ paneId: "13", isActive: true }],
+            panes: [{ paneId: "13", isActive: true, rawPaneRecord: { sourceFormat: "wezterm-array" } }],
           },
         ],
       },
@@ -129,7 +137,7 @@ describe("runWeztermCli", () => {
 
     const result = await listWeztermWindows()
 
-    expect(result.windows).toEqual([
+    expect(result.windows).toMatchObject([
       {
         windowId: "w1",
         isActive: true,
@@ -138,7 +146,7 @@ describe("runWeztermCli", () => {
           {
             tabId: "tab-1",
             isActive: true,
-            panes: [{ paneId: "10", isActive: true }],
+            panes: [{ paneId: "10", isActive: true, rawPaneRecord: { sourceFormat: "wezterm-object" } }],
           },
         ],
       },
@@ -154,7 +162,7 @@ describe("runWeztermCli", () => {
 
     const result = await listWeztermWindows()
 
-    expect(result.windows).toEqual([
+    expect(result.windows).toMatchObject([
       {
         windowId: "w1",
         isActive: true,
@@ -163,12 +171,12 @@ describe("runWeztermCli", () => {
           {
             tabId: "w1",
             isActive: false,
-            panes: [{ paneId: "10", isActive: false }],
+            panes: [{ paneId: "10", isActive: false, rawPaneRecord: { sourceFormat: "wezterm-array" } }],
           },
           {
             tabId: "tab-2",
             isActive: true,
-            panes: [{ paneId: "11", isActive: true }],
+            panes: [{ paneId: "11", isActive: true, rawPaneRecord: { sourceFormat: "wezterm-array" } }],
           },
         ],
       },

--- a/src/backends/wezterm/cli.ts
+++ b/src/backends/wezterm/cli.ts
@@ -6,7 +6,7 @@ import { parseWeztermListResult, type WeztermListResult } from "./list-parser"
 export type { WeztermListResult } from "./list-parser"
 
 const WEZTERM_BINARY = "wezterm"
-const MINIMUM_VERSION = "20220624-141144-bd1b7c5d"
+export const WEZTERM_MINIMUM_VERSION = "20220624-141144-bd1b7c5d"
 const VERSION_REGEX = /(\d{8})-(\d{6})-([0-9a-fA-F]+)/i
 
 type ExecaLikeError = Error & {
@@ -39,14 +39,14 @@ export const verifyWeztermAvailability = async (): Promise<{ version: string }> 
   const detectedVersion = extractVersion(stdout)
   if (detectedVersion === undefined) {
     throw createEnvironmentError("Unable to determine wezterm version", ErrorCodes.UNSUPPORTED_WEZTERM_VERSION, {
-      requiredVersion: MINIMUM_VERSION,
+      requiredVersion: WEZTERM_MINIMUM_VERSION,
       detectedVersion: stdout.trim(),
     })
   }
 
-  if (!isVersionSupported(detectedVersion, MINIMUM_VERSION)) {
+  if (!isVersionSupported(detectedVersion, WEZTERM_MINIMUM_VERSION)) {
     throw createEnvironmentError("Unsupported wezterm version", ErrorCodes.UNSUPPORTED_WEZTERM_VERSION, {
-      requiredVersion: MINIMUM_VERSION,
+      requiredVersion: WEZTERM_MINIMUM_VERSION,
       detectedVersion,
     })
   }

--- a/src/backends/wezterm/dry-run.ts
+++ b/src/backends/wezterm/dry-run.ts
@@ -1,3 +1,4 @@
+import { type PaneDimensions, updatePaneSizes } from "../pane-tracking"
 import type { PlanEmission } from "../../core/emitter"
 import { createCoreError, isCoreError } from "../../core/errors"
 import { resolveSplitOrientation, resolveSplitSize, type ResolvedSplitSize } from "../../executor/split-step"
@@ -5,14 +6,8 @@ import { resolveRequiredStepTargetPaneId } from "../../executor/step-target"
 import { prepareTerminalCommands } from "../../executor/terminal-command-preparation"
 import type { DryRunStep } from "../../executor/terminal-backend"
 import { ErrorCodes } from "../../utils/errors"
-
 const SINGLE_QUOTE = "'"
 const SHELL_SINGLE_QUOTE_ESCAPE = `'"'"'`
-
-type PaneDimensions = {
-  readonly cols: number
-  readonly rows: number
-}
 
 type SplitArgumentSize =
   | ResolvedSplitSize
@@ -227,34 +222,4 @@ const resolveDryRunSplitSize = ({
     paneId: targetPaneId,
     detectedVersion,
   })
-}
-
-const updatePaneSizes = ({
-  paneSizes,
-  targetPaneId,
-  createdPaneId,
-  orientation,
-  targetCells,
-  createdCells,
-}: {
-  readonly paneSizes: Map<string, PaneDimensions>
-  readonly targetPaneId: string
-  readonly createdPaneId: string
-  readonly orientation: "horizontal" | "vertical"
-  readonly targetCells: number
-  readonly createdCells: number
-}): void => {
-  const base = paneSizes.get(targetPaneId)
-  if (base === undefined) {
-    return
-  }
-
-  if (orientation === "horizontal") {
-    paneSizes.set(targetPaneId, { cols: targetCells, rows: base.rows })
-    paneSizes.set(createdPaneId, { cols: createdCells, rows: base.rows })
-    return
-  }
-
-  paneSizes.set(targetPaneId, { cols: base.cols, rows: targetCells })
-  paneSizes.set(createdPaneId, { cols: base.cols, rows: createdCells })
 }

--- a/src/backends/wezterm/list-parser.test.ts
+++ b/src/backends/wezterm/list-parser.test.ts
@@ -5,12 +5,12 @@ import { parseWeztermListResult } from "./list-parser"
 describe("parseWeztermListResult", () => {
   it("parses array-form list output and groups panes by window/tab", () => {
     const stdout = JSON.stringify([
-      { window_id: 1, tab_id: 2, pane_id: 10, is_active: true },
+      { window_id: 1, tab_id: 2, pane_id: 10, is_active: true, size: { cols: 120, rows: 40 } },
       { window_id: 1, tab_id: 2, pane_id: 11, is_active: false },
       { window_id: 1, tab_id: 3, pane_id: 12, is_active: false },
     ])
 
-    expect(parseWeztermListResult(stdout)).toEqual({
+    expect(parseWeztermListResult(stdout)).toMatchObject({
       windows: [
         {
           windowId: "1",
@@ -21,14 +21,47 @@ describe("parseWeztermListResult", () => {
               tabId: "2",
               isActive: true,
               panes: [
-                { paneId: "10", isActive: true },
-                { paneId: "11", isActive: false },
+                {
+                  paneId: "10",
+                  isActive: true,
+                  size: { cols: 120, rows: 40 },
+                  rawPaneRecord: {
+                    backend: "wezterm",
+                    windowId: "1",
+                    tabId: "2",
+                    paneId: "10",
+                    sourceFormat: "wezterm-array",
+                  },
+                },
+                {
+                  paneId: "11",
+                  isActive: false,
+                  rawPaneRecord: {
+                    backend: "wezterm",
+                    windowId: "1",
+                    tabId: "2",
+                    paneId: "11",
+                    sourceFormat: "wezterm-array",
+                  },
+                },
               ],
             },
             {
               tabId: "3",
               isActive: false,
-              panes: [{ paneId: "12", isActive: false }],
+              panes: [
+                {
+                  paneId: "12",
+                  isActive: false,
+                  rawPaneRecord: {
+                    backend: "wezterm",
+                    windowId: "1",
+                    tabId: "3",
+                    paneId: "12",
+                    sourceFormat: "wezterm-array",
+                  },
+                },
+              ],
             },
           ],
         },
@@ -61,7 +94,7 @@ describe("parseWeztermListResult", () => {
       ],
     })
 
-    expect(parseWeztermListResult(stdout)).toEqual({
+    expect(parseWeztermListResult(stdout)).toMatchObject({
       windows: [
         {
           windowId: "w1",
@@ -71,7 +104,19 @@ describe("parseWeztermListResult", () => {
             {
               tabId: "tab-1",
               isActive: true,
-              panes: [{ paneId: "10", isActive: true }],
+              panes: [
+                {
+                  paneId: "10",
+                  isActive: true,
+                  rawPaneRecord: {
+                    backend: "wezterm",
+                    windowId: "w1",
+                    tabId: "tab-1",
+                    paneId: "10",
+                    sourceFormat: "wezterm-object",
+                  },
+                },
+              ],
             },
           ],
         },

--- a/src/backends/wezterm/list-parser.ts
+++ b/src/backends/wezterm/list-parser.ts
@@ -1,6 +1,23 @@
-type WeztermListPane = {
+export type WeztermPaneSize = {
+  readonly cols?: number
+  readonly rows?: number
+}
+
+export type WeztermRawPaneRecord = {
+  readonly backend: "wezterm"
+  readonly windowId?: string
+  readonly tabId?: string
+  readonly paneId: string
+  readonly isActive?: boolean
+  readonly size?: WeztermPaneSize
+  readonly sourceFormat: "wezterm-array" | "wezterm-object" | "unknown"
+}
+
+export type WeztermListPane = {
   readonly paneId: string
   readonly isActive: boolean
+  readonly size?: WeztermPaneSize
+  readonly rawPaneRecord: WeztermRawPaneRecord
 }
 
 type WeztermListTab = {
@@ -20,9 +37,15 @@ export type WeztermListResult = {
   readonly windows: ReadonlyArray<WeztermListWindow>
 }
 
+type RawListSize = {
+  readonly cols?: unknown
+  readonly rows?: unknown
+}
+
 type RawListPane = {
   readonly pane_id?: number | string
   readonly is_active?: unknown
+  readonly size?: RawListSize
 }
 
 type RawListTab = {
@@ -44,6 +67,7 @@ type RawListEntry = {
   readonly pane_id?: number | string
   readonly workspace?: unknown
   readonly is_active?: unknown
+  readonly size?: RawListSize
 }
 
 type RawListResult = {
@@ -71,6 +95,29 @@ const toWorkspaceString = (value: unknown): string | undefined => {
   return undefined
 }
 
+const toPositiveInteger = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return undefined
+  }
+  return value
+}
+
+const toPaneSize = (value: unknown): WeztermPaneSize | undefined => {
+  if (typeof value !== "object" || value === null) {
+    return undefined
+  }
+  const raw = value as RawListSize
+  const cols = toPositiveInteger(raw.cols)
+  const rows = toPositiveInteger(raw.rows)
+  if (cols === undefined && rows === undefined) {
+    return undefined
+  }
+  return {
+    cols,
+    rows,
+  }
+}
+
 type MutableTabRecord = {
   tabId: string
   isActive: boolean
@@ -90,6 +137,7 @@ type NormalizedArrayEntry = {
   paneId: string
   workspace?: string
   isActive: boolean
+  size?: WeztermPaneSize
 }
 
 const toImmutablePanes = (panes: ReadonlyArray<WeztermListPane>): WeztermListPane[] => {
@@ -97,6 +145,8 @@ const toImmutablePanes = (panes: ReadonlyArray<WeztermListPane>): WeztermListPan
     (pane): WeztermListPane => ({
       paneId: pane.paneId,
       isActive: pane.isActive,
+      ...(pane.size !== undefined ? { size: pane.size } : {}),
+      rawPaneRecord: pane.rawPaneRecord,
     }),
   )
 }
@@ -139,6 +189,7 @@ const normalizeArrayEntry = (entry: unknown): NormalizedArrayEntry | undefined =
     paneId: paneIdRaw,
     workspace: toWorkspaceString(listEntry.workspace),
     isActive: listEntry.is_active === true,
+    size: toPaneSize(listEntry.size),
   }
 }
 
@@ -177,6 +228,18 @@ const getOrCreateTabRecord = (windowRecord: MutableWindowRecord, tabId: string):
   return createdTab
 }
 
+const createArrayRawPaneRecord = (entry: NormalizedArrayEntry): WeztermRawPaneRecord => {
+  return {
+    backend: "wezterm",
+    windowId: entry.windowId,
+    tabId: entry.tabId,
+    paneId: entry.paneId,
+    isActive: entry.isActive,
+    size: entry.size,
+    sourceFormat: "wezterm-array",
+  }
+}
+
 const parseArrayResponse = (parsed: unknown): WeztermListResult | undefined => {
   if (!Array.isArray(parsed)) {
     return undefined
@@ -197,13 +260,18 @@ const parseArrayResponse = (parsed: unknown): WeztermListResult | undefined => {
     tabRecord.panes.push({
       paneId: normalizedEntry.paneId,
       isActive: normalizedEntry.isActive,
+      ...(normalizedEntry.size !== undefined ? { size: normalizedEntry.size } : {}),
+      rawPaneRecord: createArrayRawPaneRecord(normalizedEntry),
     })
   }
 
   return { windows: toImmutableWindows(windowMap) }
 }
 
-const parseObjectPane = (pane: unknown): WeztermListPane | undefined => {
+const parseObjectPane = (
+  pane: unknown,
+  context: { readonly windowId: string; readonly tabId: string },
+): WeztermListPane | undefined => {
   if (typeof pane !== "object" || pane === null) {
     return undefined
   }
@@ -212,13 +280,25 @@ const parseObjectPane = (pane: unknown): WeztermListPane | undefined => {
   if (!isNonEmptyString(paneIdRaw)) {
     return undefined
   }
+
+  const size = toPaneSize(rawPane.size)
   return {
     paneId: paneIdRaw,
     isActive: rawPane.is_active === true,
+    ...(size !== undefined ? { size } : {}),
+    rawPaneRecord: {
+      backend: "wezterm",
+      windowId: context.windowId,
+      tabId: context.tabId,
+      paneId: paneIdRaw,
+      isActive: rawPane.is_active === true,
+      size,
+      sourceFormat: "wezterm-object",
+    },
   }
 }
 
-const parseObjectTab = (tab: unknown): WeztermListTab | undefined => {
+const parseObjectTab = (tab: unknown, context: { readonly windowId: string }): WeztermListTab | undefined => {
   if (typeof tab !== "object" || tab === null) {
     return undefined
   }
@@ -231,7 +311,10 @@ const parseObjectTab = (tab: unknown): WeztermListTab | undefined => {
   const paneRecords = Array.isArray(rawTab.panes) ? rawTab.panes : []
   const panes: WeztermListPane[] = []
   for (const pane of paneRecords) {
-    const mappedPane = parseObjectPane(pane)
+    const mappedPane = parseObjectPane(pane, {
+      windowId: context.windowId,
+      tabId: tabIdRaw,
+    })
     if (mappedPane) {
       panes.push(mappedPane)
     }
@@ -257,7 +340,7 @@ const parseObjectWindow = (window: unknown): WeztermListWindow | undefined => {
   const tabs: WeztermListTab[] = []
   const rawTabs = Array.isArray(rawWindow.tabs) ? rawWindow.tabs : []
   for (const tab of rawTabs) {
-    const mappedTab = parseObjectTab(tab)
+    const mappedTab = parseObjectTab(tab, { windowId: windowIdRaw })
     if (mappedTab) {
       tabs.push(mappedTab)
     }

--- a/src/backends/wezterm/list-parser.ts
+++ b/src/backends/wezterm/list-parser.ts
@@ -240,6 +240,28 @@ const createArrayRawPaneRecord = (entry: NormalizedArrayEntry): WeztermRawPaneRe
   }
 }
 
+const createObjectRawPaneRecord = ({
+  rawPane,
+  context,
+  paneId,
+  size,
+}: {
+  readonly rawPane: RawListPane
+  readonly context: { readonly windowId: string; readonly tabId: string }
+  readonly paneId: string
+  readonly size?: WeztermPaneSize
+}): WeztermRawPaneRecord => {
+  return {
+    backend: "wezterm",
+    windowId: context.windowId,
+    tabId: context.tabId,
+    paneId,
+    isActive: rawPane.is_active === true,
+    size,
+    sourceFormat: "wezterm-object",
+  }
+}
+
 const parseArrayResponse = (parsed: unknown): WeztermListResult | undefined => {
   if (!Array.isArray(parsed)) {
     return undefined
@@ -286,15 +308,12 @@ const parseObjectPane = (
     paneId: paneIdRaw,
     isActive: rawPane.is_active === true,
     ...(size !== undefined ? { size } : {}),
-    rawPaneRecord: {
-      backend: "wezterm",
-      windowId: context.windowId,
-      tabId: context.tabId,
+    rawPaneRecord: createObjectRawPaneRecord({
+      rawPane,
+      context,
       paneId: paneIdRaw,
-      isActive: rawPane.is_active === true,
       size,
-      sourceFormat: "wezterm-object",
-    },
+    }),
   }
 }
 

--- a/src/backends/wezterm/step-execution.ts
+++ b/src/backends/wezterm/step-execution.ts
@@ -6,6 +6,7 @@ import { waitForDelay } from "../../utils/async"
 import { ErrorCodes } from "../../utils/errors"
 import { buildSplitArguments } from "./dry-run"
 import { collectPaneIdsForWindow } from "./layout-resolution"
+import type { WeztermPaneSize, WeztermRawPaneRecord } from "./list-parser"
 import { registerPaneWithAncestors, resolveRealPaneId } from "./pane-map"
 import type { ExecuteWeztermCommand, ListWeztermWindows, LogPaneMapping, PaneMap } from "./shared"
 import { WEZTERM_MINIMUM_VERSION, type WeztermListResult } from "./cli"
@@ -138,8 +139,8 @@ const findPaneById = (
   paneId: string,
 ):
   | {
-      readonly size?: { readonly cols?: number; readonly rows?: number }
-      readonly rawPaneRecord?: Record<string, unknown>
+      readonly size?: WeztermPaneSize
+      readonly rawPaneRecord?: WeztermRawPaneRecord
     }
   | undefined => {
   for (const window of list.windows) {

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -92,7 +92,10 @@ describe("CLI", () => {
     layout: {
       kind: "split",
       orientation: "horizontal",
-      ratio: [0.5, 0.5],
+      ratio: [
+        { kind: "weight", weight: 1 },
+        { kind: "weight", weight: 1 },
+      ],
       panes: [
         {
           kind: "terminal",
@@ -114,7 +117,10 @@ describe("CLI", () => {
       kind: "split",
       id: "root",
       orientation: "horizontal",
-      ratio: [0.5, 0.5],
+      ratio: [
+        { kind: "weight", weight: 1 },
+        { kind: "weight", weight: 1 },
+      ],
       panes: [
         {
           kind: "terminal",

--- a/src/cli/wezterm.test.ts
+++ b/src/cli/wezterm.test.ts
@@ -28,7 +28,10 @@ const samplePreset: CompiledPreset = {
   layout: {
     kind: "split",
     orientation: "horizontal",
-    ratio: [0.5, 0.5],
+    ratio: [
+      { kind: "weight", weight: 1 },
+      { kind: "weight", weight: 1 },
+    ],
     panes: [
       {
         kind: "terminal",
@@ -51,7 +54,10 @@ const samplePlan: LayoutPlan = {
     kind: "split",
     id: "root",
     orientation: "horizontal",
-    ratio: [0.5, 0.5],
+    ratio: [
+      { kind: "weight", weight: 1 },
+      { kind: "weight", weight: 1 },
+    ],
     panes: [
       {
         kind: "terminal",

--- a/src/core/compile.test.ts
+++ b/src/core/compile.test.ts
@@ -32,7 +32,10 @@ layout:
     expect(root).toMatchObject({
       kind: "split",
       orientation: "horizontal",
-      ratio: [1, 2],
+      ratio: [
+        { kind: "weight", weight: 1 },
+        { kind: "weight", weight: 2 },
+      ],
     })
     expect(root?.kind === "split" ? root.panes[0] : undefined).toMatchObject({
       kind: "terminal",
@@ -193,7 +196,34 @@ layout:
     expect(result.preset.layout).toMatchObject({
       kind: "split",
       orientation: "horizontal",
-      ratio: [1, 1],
+      ratio: [
+        { kind: "weight", weight: 1 },
+        { kind: "weight", weight: 1 },
+      ],
+    })
+  })
+
+  it("converts mixed ratio entries into weight/fixed-cells", () => {
+    const result = compilePresetFromValue({
+      source: "tests/value-input-mixed-ratio",
+      value: {
+        name: "mixed-ratio",
+        layout: {
+          type: "horizontal",
+          ratio: ["90c", 2, 1],
+          panes: [{ name: "left" }, { name: "middle" }, { name: "right" }],
+        },
+      },
+    })
+
+    expect(result.preset.layout).toMatchObject({
+      kind: "split",
+      orientation: "horizontal",
+      ratio: [
+        { kind: "fixed-cells", cells: 90 },
+        { kind: "weight", weight: 2 },
+        { kind: "weight", weight: 1 },
+      ],
     })
   })
 
@@ -308,6 +338,29 @@ layout:
       expect(isCoreError(error)).toBe(true)
       if (isCoreError(error)) {
         expect(error.code).toBe("LAYOUT_INVALID_NODE")
+      }
+    }
+  })
+
+  it("returns RATIO_WEIGHT_MISSING for fixed-cells-only ratios", () => {
+    expect.assertions(2)
+    try {
+      compilePresetFromValue({
+        source: "tests/value-input-fixed-only-ratio",
+        value: {
+          name: "fixed-only-ratio",
+          layout: {
+            type: "horizontal",
+            ratio: ["40c", "20c"],
+            panes: [{ name: "left" }, { name: "right" }],
+          },
+        },
+      })
+      throw new Error("expected failure")
+    } catch (error) {
+      expect(isCoreError(error)).toBe(true)
+      if (isCoreError(error)) {
+        expect(error.code).toBe("RATIO_WEIGHT_MISSING")
       }
     }
   })

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -27,10 +27,14 @@ export type CompiledTerminalPane = {
   readonly options?: Readonly<Record<string, unknown>>
 }
 
+export type CompiledRatioEntry =
+  | { readonly kind: "weight"; readonly weight: number }
+  | { readonly kind: "fixed-cells"; readonly cells: number }
+
 export type CompiledSplitPane = {
   readonly kind: "split"
   readonly orientation: "horizontal" | "vertical"
-  readonly ratio: ReadonlyArray<number>
+  readonly ratio: ReadonlyArray<CompiledRatioEntry>
   readonly panes: ReadonlyArray<CompiledLayoutNode>
 }
 
@@ -72,6 +76,8 @@ export const compilePreset = ({ document, source }: CompilePresetInput): Compile
 export const compilePresetFromValue = ({ value, source }: CompilePresetFromValueInput): CompilePresetSuccess => {
   return compilePresetValue({ value, source })
 }
+
+const FIXED_RATIO_PATTERN = /^([1-9][0-9]*)c$/
 
 const compilePresetValue = ({ value, source }: CompilePresetFromValueInput): CompilePresetSuccess => {
   const parsed = value
@@ -201,7 +207,22 @@ const parseSplitPane = (
       path: `${context.path}.panes[${index}]`,
     }),
   )
-  const ratio = ratioInput.map((value): number => Number(value))
+  const ratio = ratioInput.map(
+    (value, index): CompiledRatioEntry =>
+      parseRatioEntry(value, {
+        source: context.source,
+        path: `${context.path}.ratio[${index}]`,
+      }),
+  )
+
+  if (!ratio.some((entry) => entry.kind === "weight")) {
+    throw compileError("RATIO_WEIGHT_MISSING", {
+      source: context.source,
+      message: "ratio must include at least one numeric weight",
+      path: `${context.path}.ratio`,
+      details: { ratio: ratioInput },
+    })
+  }
 
   return {
     kind: "split",
@@ -209,6 +230,38 @@ const parseSplitPane = (
     ratio,
     panes: panes.filter((pane): pane is CompiledLayoutNode => pane !== null),
   }
+}
+
+const parseRatioEntry = (
+  value: unknown,
+  context: { readonly source: string; readonly path: string },
+): CompiledRatioEntry => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return {
+      kind: "weight",
+      weight: value,
+    }
+  }
+
+  if (typeof value === "string") {
+    const match = value.match(FIXED_RATIO_PATTERN)
+    if (match?.[1] !== undefined) {
+      const parsed = Number(match[1])
+      if (Number.isInteger(parsed) && parsed > 0) {
+        return {
+          kind: "fixed-cells",
+          cells: parsed,
+        }
+      }
+    }
+  }
+
+  throw compileError("RATIO_INVALID_VALUE", {
+    source: context.source,
+    message: 'ratio value must be a positive number or "<positive-integer>c"',
+    path: context.path,
+    details: { value },
+  })
 }
 
 const parseTerminalPane = (node: Record<string, unknown>): CompiledTerminalPane => {
@@ -365,10 +418,22 @@ const convertLayoutIssueToCompileError = ({
     })
   }
 
+  if (issue.message.includes("ratio must include at least one numeric weight")) {
+    const ratio = isRecord(layout) ? layout.ratio : undefined
+    return compileError("RATIO_WEIGHT_MISSING", {
+      source,
+      message: "ratio must include at least one numeric weight",
+      path: `${basePath}.ratio`,
+      details: {
+        ratio,
+      },
+    })
+  }
+
   if (issue.path.includes("ratio")) {
     return compileError("RATIO_INVALID_VALUE", {
       source,
-      message: "ratio value must be a positive number",
+      message: 'ratio value must be a positive number or "<positive-integer>c"',
       path: formatPath(basePath, issue.path),
       details: {
         value: getValueAtPath(layout, issue.path),

--- a/src/core/emitter.test.ts
+++ b/src/core/emitter.test.ts
@@ -23,6 +23,10 @@ layout:
       kind: "split",
       orientation: "horizontal",
       percentage: 50,
+      splitSizing: {
+        mode: "percent",
+        percentage: 50,
+      },
       targetPaneId: "root.0",
     })
     expect(emission.steps[0]?.command).toBeUndefined()
@@ -119,6 +123,10 @@ layout:
         id: "root:split:1",
         orientation: "horizontal",
         percentage: 67,
+        splitSizing: {
+          mode: "percent",
+          percentage: 67,
+        },
         targetPaneId: "root.0",
         createdPaneId: "root.1",
       }),
@@ -126,6 +134,10 @@ layout:
         id: "root:split:2",
         orientation: "horizontal",
         percentage: 50,
+        splitSizing: {
+          mode: "percent",
+          percentage: 50,
+        },
         targetPaneId: "root.1",
         createdPaneId: "root.2",
       }),
@@ -133,6 +145,10 @@ layout:
         id: "root.1:split:1",
         orientation: "vertical",
         percentage: 67,
+        splitSizing: {
+          mode: "percent",
+          percentage: 67,
+        },
         targetPaneId: "root.1.0",
         createdPaneId: "root.1.1",
       }),
@@ -159,5 +175,46 @@ layout:
     const second = emitPlan({ plan })
 
     expect(first.hash).toBe(second.hash)
+  })
+
+  it("emits dynamic-cells sizing metadata when fixed cells are present", () => {
+    const document = `
+name: dynamic-sample
+layout:
+  type: horizontal
+  ratio: ["90c", 2, 1]
+  panes:
+    - name: left
+    - name: middle
+    - name: right
+`
+
+    const { preset } = compilePreset({ document, source: "tests/dynamic.yml" })
+    const { plan } = createLayoutPlan({ preset })
+    const emission = emitPlan({ plan })
+    const splitSteps = emission.steps.filter((step) => step.kind === "split")
+
+    expect(splitSteps).toEqual([
+      expect.objectContaining({
+        id: "root:split:1",
+        splitSizing: {
+          mode: "dynamic-cells",
+          target: { kind: "fixed-cells", cells: 90 },
+          remainingFixedCells: 0,
+          remainingWeight: 3,
+          remainingWeightPaneCount: 2,
+        },
+      }),
+      expect.objectContaining({
+        id: "root:split:2",
+        splitSizing: {
+          mode: "dynamic-cells",
+          target: { kind: "weight", weight: 2 },
+          remainingFixedCells: 0,
+          remainingWeight: 1,
+          remainingWeightPaneCount: 1,
+        },
+      }),
+    ])
   })
 })

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,7 +4,13 @@ export { createLayoutPlan } from "./planner"
 export { emitPlan } from "./emitter"
 export { compileCorePipeline } from "./pipeline"
 
-export type { CompilePresetInput, CompilePresetFromValueInput, CompilePresetSuccess, CompiledPreset } from "./compile"
+export type {
+  CompilePresetInput,
+  CompilePresetFromValueInput,
+  CompilePresetSuccess,
+  CompiledPreset,
+  CompiledRatioEntry,
+} from "./compile"
 export type { CreateLayoutPlanSuccess, LayoutPlan, PlanNode } from "./planner"
 export type { PlanEmission } from "./emitter"
 export type { CoreError } from "./errors"

--- a/src/core/pipeline.test.ts
+++ b/src/core/pipeline.test.ts
@@ -60,7 +60,10 @@ describe("compileCorePipeline", () => {
           layout: {
             kind: "split",
             orientation: "horizontal",
-            ratio: [0.5, 0.5],
+            ratio: [
+              { kind: "weight", weight: 1 },
+              { kind: "weight", weight: 1 },
+            ],
             panes: [
               { kind: "terminal", name: "one", command: "nvim", focus: true },
               { kind: "terminal", name: "two" },
@@ -80,7 +83,10 @@ describe("compileCorePipeline", () => {
               kind: "split",
               id: "root",
               orientation: "horizontal",
-              ratio: [0.5, 0.5],
+              ratio: [
+                { kind: "weight", weight: 1 },
+                { kind: "weight", weight: 1 },
+              ],
               panes: [
                 { kind: "terminal", id: "root.0", name: "one", focus: true },
                 { kind: "terminal", id: "root.1", name: "two", focus: false },

--- a/src/executor/mock-executor.ts
+++ b/src/executor/mock-executor.ts
@@ -42,6 +42,14 @@ export const createMockExecutor = (): MockExecutor => {
       return "%0"
     }
 
+    if (args.includes("display-message") && args.includes("#{pane_width}")) {
+      return "200"
+    }
+
+    if (args.includes("display-message") && args.includes("#{pane_height}")) {
+      return "60"
+    }
+
     if (args.includes("display-message") && args.includes("#{pane_id}")) {
       return mockPaneIds[0] ?? "%0"
     }

--- a/src/executor/mock-executor.ts
+++ b/src/executor/mock-executor.ts
@@ -42,16 +42,20 @@ export const createMockExecutor = (): MockExecutor => {
       return "%0"
     }
 
-    if (args.includes("display-message") && args.includes("#{pane_width}")) {
-      return "200"
-    }
-
-    if (args.includes("display-message") && args.includes("#{pane_height}")) {
-      return "60"
-    }
-
-    if (args.includes("display-message") && args.includes("#{pane_id}")) {
-      return mockPaneIds[0] ?? "%0"
+    if (args.includes("display-message")) {
+      const parts: string[] = []
+      if (args.includes("#{pane_id}")) {
+        parts.push(mockPaneIds[0] ?? "%0")
+      }
+      if (args.includes("#{pane_width}")) {
+        parts.push("200")
+      }
+      if (args.includes("#{pane_height}")) {
+        parts.push("60")
+      }
+      if (parts.length > 0) {
+        return parts.join(" ")
+      }
     }
 
     if (args.includes("list-panes") && args.includes("#{pane_id}")) {

--- a/src/executor/plan-runner-helpers.ts
+++ b/src/executor/plan-runner-helpers.ts
@@ -288,9 +288,16 @@ const buildSplitCommand = async ({
   readonly executor: CommandExecutor
   readonly detectedVersion?: string
 }): Promise<string[]> => {
-  const directionFlag = resolveSplitOrientation(step) === "horizontal" ? "-h" : "-v"
+  const orientation = resolveSplitOrientation(step)
+  const directionFlag = orientation === "horizontal" ? "-h" : "-v"
   if (isDynamicSplit(step)) {
-    const paneCells = await resolveTmuxPaneCells({ executor, step, targetRealId, detectedVersion })
+    const paneCells = await resolveTmuxPaneCells({
+      executor,
+      step,
+      targetRealId,
+      orientation,
+      detectedVersion,
+    })
     const splitSize = resolveSplitSize(step, {
       paneCells,
       paneId: targetRealId,
@@ -346,14 +353,15 @@ const resolveTmuxPaneCells = async ({
   executor,
   step,
   targetRealId,
+  orientation,
   detectedVersion,
 }: {
   readonly executor: CommandExecutor
   readonly step: CommandStep
   readonly targetRealId: string
+  readonly orientation: "horizontal" | "vertical"
   readonly detectedVersion?: string
 }): Promise<number> => {
-  const orientation = resolveSplitOrientation(step)
   const format = orientation === "horizontal" ? "#{pane_width}" : "#{pane_height}"
   const output = await executeCommand(executor, ["display-message", "-p", "-t", targetRealId, format], {
     code: ErrorCodes.TMUX_COMMAND_FAILED,

--- a/src/executor/plan-runner-helpers.ts
+++ b/src/executor/plan-runner-helpers.ts
@@ -4,17 +4,19 @@ import type { CommandExecutor } from "../contracts"
 import { waitForDelay } from "../utils/async"
 import { ErrorCodes } from "../utils/errors"
 import { resolvePaneMapping } from "../utils/pane-map"
-import { resolveSplitOrientation, resolveSplitPercentage } from "./split-step"
+import { resolveSplitOrientation, resolveSplitSize } from "./split-step"
 import { prepareTerminalCommands } from "./terminal-command-preparation"
 
 export const executeSplitStep = async ({
   step,
   executor,
   paneMap,
+  detectedVersion,
 }: {
   readonly step: CommandStep
   readonly executor: CommandExecutor
   readonly paneMap: Map<string, string>
+  readonly detectedVersion?: string
 }): Promise<void> => {
   const targetVirtualId = ensureNonEmpty(step.targetPaneId, () =>
     raiseExecutionError(ErrorCodes.MISSING_TARGET, {
@@ -31,7 +33,12 @@ export const executeSplitStep = async ({
   )
 
   const panesBefore = await listPaneIds(executor, step)
-  const splitCommand = buildSplitCommand(step, targetRealId)
+  const splitCommand = await buildSplitCommand({
+    step,
+    targetRealId,
+    executor,
+    detectedVersion,
+  })
   await executeCommand(executor, splitCommand, {
     code: ErrorCodes.TMUX_COMMAND_FAILED,
     message: `Failed to execute split step ${step.id}`,
@@ -270,10 +277,52 @@ const findNewPaneId = (before: string[], after: string[]): string | undefined =>
   return after.find((id) => !beforeSet.has(id))
 }
 
-const buildSplitCommand = (step: CommandStep, targetRealId: string): string[] => {
+const buildSplitCommand = async ({
+  step,
+  targetRealId,
+  executor,
+  detectedVersion,
+}: {
+  readonly step: CommandStep
+  readonly targetRealId: string
+  readonly executor: CommandExecutor
+  readonly detectedVersion?: string
+}): Promise<string[]> => {
   const directionFlag = resolveSplitOrientation(step) === "horizontal" ? "-h" : "-v"
-  const percentage = resolveSplitPercentage(step)
-  return ["split-window", directionFlag, "-t", targetRealId, "-p", percentage]
+  if (isDynamicSplit(step)) {
+    const paneCells = await resolveTmuxPaneCells({ executor, step, targetRealId, detectedVersion })
+    const splitSize = resolveSplitSize(step, {
+      paneCells,
+      paneId: targetRealId,
+      detectedVersion,
+      rawPaneRecord: {
+        backend: "tmux",
+        paneId: targetRealId,
+        sourceFormat: "tmux-format",
+      },
+    })
+    if (splitSize.mode === "cells") {
+      return ["split-window", directionFlag, "-t", targetRealId, "-l", splitSize.cells]
+    }
+    return raiseExecutionError(ErrorCodes.INVALID_PLAN, {
+      message: "Dynamic split resolved to a non-cell sizing mode",
+      path: step.id,
+      details: { splitSize },
+    })
+  }
+
+  const splitSize = resolveSplitSize(step, {
+    paneId: targetRealId,
+    detectedVersion,
+  })
+  if (splitSize.mode === "percent") {
+    return ["split-window", directionFlag, "-t", targetRealId, "-p", splitSize.percentage]
+  }
+  return raiseExecutionError(ErrorCodes.INVALID_PLAN, {
+    message: "Percent split resolved to a non-percent sizing mode",
+    path: step.id,
+    details: { splitSize },
+  })
 }
 
 const buildFocusCommand = (targetRealId: string): string[] => {
@@ -291,6 +340,45 @@ export const registerPane = (paneMap: Map<string, string>, virtualId: string, re
 
 export const resolvePaneId = (paneMap: Map<string, string>, virtualId: string): string | undefined => {
   return resolvePaneMapping(paneMap, virtualId)
+}
+
+const resolveTmuxPaneCells = async ({
+  executor,
+  step,
+  targetRealId,
+  detectedVersion,
+}: {
+  readonly executor: CommandExecutor
+  readonly step: CommandStep
+  readonly targetRealId: string
+  readonly detectedVersion?: string
+}): Promise<number> => {
+  const orientation = resolveSplitOrientation(step)
+  const format = orientation === "horizontal" ? "#{pane_width}" : "#{pane_height}"
+  const output = await executeCommand(executor, ["display-message", "-p", "-t", targetRealId, format], {
+    code: ErrorCodes.TMUX_COMMAND_FAILED,
+    message: "Failed to resolve tmux pane size",
+    path: step.id,
+    details: { command: ["display-message", "-p", "-t", targetRealId, format] },
+  })
+  const value = Number.parseInt(output.trim(), 10)
+  if (!Number.isInteger(value) || value <= 0) {
+    raiseExecutionError(ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED, {
+      message: "Unable to parse tmux pane size",
+      path: step.id,
+      details: {
+        paneId: targetRealId,
+        orientation,
+        output,
+        detectedVersion,
+      },
+    })
+  }
+  return value
+}
+
+const isDynamicSplit = (step: CommandStep): boolean => {
+  return step.kind === "split" && step.splitSizing?.mode === "dynamic-cells"
 }
 
 const ensureNonEmpty = <T extends string>(value: T | undefined, buildError: () => never): T => {

--- a/src/executor/plan-runner.test.ts
+++ b/src/executor/plan-runner.test.ts
@@ -138,6 +138,37 @@ describe("executePlan", () => {
     })
   })
 
+  it("uses -l with resolved cells for dynamic-cells split sizing", async () => {
+    const executor = createMockExecutor()
+    const emission: PlanEmission = {
+      ...baseEmission,
+      steps: [
+        {
+          ...baseSplitStep,
+          orientation: "horizontal",
+          splitSizing: {
+            mode: "dynamic-cells",
+            target: { kind: "fixed-cells", cells: 90 },
+            remainingFixedCells: 0,
+            remainingWeight: 1,
+            remainingWeightPaneCount: 1,
+          },
+          percentage: undefined,
+        },
+        baseFocusStep,
+      ],
+    }
+
+    await executePlan({ emission, executor, windowMode: "new-window" })
+
+    expect(executor.getExecutedCommands()).toEqual(
+      expect.arrayContaining([
+        ["display-message", "-p", "-t", "%0", "#{pane_width}"],
+        ["split-window", "-h", "-t", "%0", "-l", "110"],
+      ]),
+    )
+  })
+
   it("reuses current window and closes other panes when current-window mode is selected", async () => {
     const executor = createMockExecutor()
     executor.setMockPaneIds(["%2", "%3"])

--- a/src/executor/plan-runner.ts
+++ b/src/executor/plan-runner.ts
@@ -22,6 +22,7 @@ type ExecutePlanInput = {
   readonly windowName?: string
   readonly windowMode: WindowMode
   readonly onConfirmKill?: ConfirmPaneClosure
+  readonly detectedVersion?: string
 }
 
 type ExecutePlanSuccess = {
@@ -34,6 +35,7 @@ export const executePlan = async ({
   windowName,
   windowMode,
   onConfirmKill,
+  detectedVersion,
 }: ExecutePlanInput): Promise<ExecutePlanSuccess> => {
   const initialVirtualPaneId = emission.summary.initialPaneId
   if (typeof initialVirtualPaneId !== "string" || initialVirtualPaneId.length === 0) {
@@ -102,7 +104,7 @@ export const executePlan = async ({
 
   for (const step of emission.steps) {
     if (step.kind === "split") {
-      await executeSplitStep({ step, executor, paneMap })
+      await executeSplitStep({ step, executor, paneMap, detectedVersion })
       executedSteps += 1
     } else if (step.kind === "focus") {
       await executeFocusStep({ step, executor, paneMap })

--- a/src/executor/split-step.test.ts
+++ b/src/executor/split-step.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { resolveSplitOrientation, resolveSplitPercentage } from "./split-step"
+import { resolveSplitOrientation, resolveSplitPercentage, resolveSplitSize } from "./split-step"
 import type { CommandStep } from "../core/emitter"
 import { ErrorCodes } from "../utils/errors"
 
@@ -12,6 +12,10 @@ const splitStep = (overrides: Partial<CommandStep> = {}): CommandStep => {
     createdPaneId: "root.1",
     orientation: "horizontal",
     percentage: 50,
+    splitSizing: {
+      mode: "percent",
+      percentage: 50,
+    },
     ...overrides,
   }
 }
@@ -32,14 +36,56 @@ describe("split-step resolvers", () => {
   })
 
   it("resolves percentage from metadata", () => {
-    expect(resolveSplitPercentage(splitStep({ percentage: 33 }))).toBe("33")
+    expect(resolveSplitPercentage(splitStep({ percentage: 33, splitSizing: undefined }))).toBe("33")
   })
 
   it("throws when percentage metadata is missing", () => {
-    expect(() => resolveSplitPercentage(splitStep({ percentage: undefined }))).toThrowError(
+    expect(() => resolveSplitPercentage(splitStep({ percentage: undefined, splitSizing: undefined }))).toThrowError(
       expect.objectContaining({
         code: ErrorCodes.INVALID_PLAN,
         path: "root:split:1",
+      }),
+    )
+  })
+
+  it("resolves dynamic split size using pane cells", () => {
+    const resolved = resolveSplitSize(
+      splitStep({
+        splitSizing: {
+          mode: "dynamic-cells",
+          target: { kind: "fixed-cells", cells: 90 },
+          remainingFixedCells: 0,
+          remainingWeight: 3,
+          remainingWeightPaneCount: 2,
+        },
+      }),
+      { paneCells: 200, paneId: "%1" },
+    )
+
+    expect(resolved).toEqual({
+      mode: "cells",
+      cells: "110",
+      targetCells: 90,
+      createdCells: 110,
+    })
+  })
+
+  it("throws SPLIT_SIZE_RESOLUTION_FAILED when dynamic split has no pane size", () => {
+    expect(() =>
+      resolveSplitSize(
+        splitStep({
+          splitSizing: {
+            mode: "dynamic-cells",
+            target: { kind: "weight", weight: 1 },
+            remainingFixedCells: 120,
+            remainingWeight: 1,
+            remainingWeightPaneCount: 1,
+          },
+        }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED,
       }),
     )
   })

--- a/src/executor/split-step.test.ts
+++ b/src/executor/split-step.test.ts
@@ -48,6 +48,27 @@ describe("split-step resolvers", () => {
     )
   })
 
+  it("throws INVALID_PLAN when resolving percentage for dynamic-cells sizing", () => {
+    expect(() =>
+      resolveSplitPercentage(
+        splitStep({
+          splitSizing: {
+            mode: "dynamic-cells",
+            target: { kind: "weight", weight: 1 },
+            remainingFixedCells: 0,
+            remainingWeight: 1,
+            remainingWeightPaneCount: 1,
+          },
+        }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_PLAN,
+        path: "root:split:1",
+      }),
+    )
+  })
+
   it("resolves dynamic split size using pane cells", () => {
     const resolved = resolveSplitSize(
       splitStep({

--- a/src/executor/split-step.ts
+++ b/src/executor/split-step.ts
@@ -1,9 +1,29 @@
-import type { CommandStep } from "../core/emitter"
+import type { CommandStep, SplitSizing } from "../core/emitter"
 import { createCoreError } from "../core/errors"
 import { ErrorCodes } from "../utils/errors"
 
 type SplitOrientation = "horizontal" | "vertical"
 type SplitCommandStep = CommandStep & { readonly kind: "split" }
+
+export type SplitSizeResolutionContext = {
+  readonly paneCells?: number
+  readonly paneId?: string
+  readonly requiredVersion?: string
+  readonly detectedVersion?: string
+  readonly rawPaneRecord?: Readonly<Record<string, unknown>>
+}
+
+export type ResolvedSplitSize =
+  | {
+      readonly mode: "percent"
+      readonly percentage: string
+    }
+  | {
+      readonly mode: "cells"
+      readonly cells: string
+      readonly targetCells: number
+      readonly createdCells: number
+    }
 
 const asSplitStep = (step: CommandStep, field: "orientation" | "percentage"): SplitCommandStep => {
   if (step.kind !== "split") {
@@ -32,21 +52,200 @@ export const resolveSplitOrientation = (step: CommandStep): SplitOrientation => 
   })
 }
 
-export const resolveSplitPercentage = (step: CommandStep): string => {
-  const splitStep = asSplitStep(step, "percentage")
+const resolveLegacySplitSizing = (step: SplitCommandStep): SplitSizing | undefined => {
+  if (typeof step.percentage === "number" && Number.isFinite(step.percentage)) {
+    return {
+      mode: "percent",
+      percentage: step.percentage,
+    }
+  }
+  return undefined
+}
 
-  if (typeof splitStep.percentage === "number" && Number.isFinite(splitStep.percentage)) {
-    return String(clampSplitPercentage(splitStep.percentage))
+const resolveSplitSizingMetadata = (step: SplitCommandStep): SplitSizing | undefined => {
+  if (step.splitSizing !== undefined) {
+    return step.splitSizing
+  }
+  return resolveLegacySplitSizing(step)
+}
+
+export const resolveSplitSize = (step: CommandStep, context: SplitSizeResolutionContext = {}): ResolvedSplitSize => {
+  const splitStep = asSplitStep(step, "percentage")
+  const splitSizing = resolveSplitSizingMetadata(splitStep)
+
+  if (splitSizing === undefined) {
+    throw createCoreError("execution", {
+      code: ErrorCodes.INVALID_PLAN,
+      message: "Split step missing sizing metadata",
+      path: splitStep.id,
+      details: {
+        splitSizing: splitStep.splitSizing,
+        percentage: splitStep.percentage,
+      },
+    })
   }
 
+  if (splitSizing.mode === "percent") {
+    if (Number.isFinite(splitSizing.percentage)) {
+      return {
+        mode: "percent",
+        percentage: String(clampSplitPercentage(splitSizing.percentage)),
+      }
+    }
+
+    throw createCoreError("execution", {
+      code: ErrorCodes.INVALID_PLAN,
+      message: "Split step missing percentage metadata",
+      path: splitStep.id,
+      details: { percentage: splitSizing.percentage },
+    })
+  }
+
+  const dynamic = splitSizing
+  const resolvedPaneCells = context.paneCells
+  if (typeof resolvedPaneCells !== "number" || !Number.isInteger(resolvedPaneCells) || resolvedPaneCells <= 0) {
+    throw createCoreError("execution", {
+      code: ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED,
+      message: "Pane size is unavailable for dynamic split sizing",
+      path: splitStep.id,
+      details: buildDynamicResolutionDetails(splitStep, dynamic, context),
+    })
+  }
+
+  const { remainingFixedCells, remainingWeight, remainingWeightPaneCount, target } = dynamic
+  if (
+    !Number.isInteger(remainingFixedCells) ||
+    remainingFixedCells < 0 ||
+    !Number.isFinite(remainingWeight) ||
+    remainingWeight < 0 ||
+    !Number.isInteger(remainingWeightPaneCount) ||
+    remainingWeightPaneCount < 0
+  ) {
+    throw createCoreError("execution", {
+      code: ErrorCodes.INVALID_PLAN,
+      message: "Split step has invalid dynamic sizing metadata",
+      path: splitStep.id,
+      details: buildDynamicResolutionDetails(splitStep, dynamic, context),
+    })
+  }
+
+  const minTargetCells = target.kind === "fixed-cells" ? target.cells : 1
+  const minCreatedCells = remainingFixedCells + remainingWeightPaneCount
+
+  if (
+    !Number.isInteger(minTargetCells) ||
+    minTargetCells <= 0 ||
+    !Number.isInteger(minCreatedCells) ||
+    minCreatedCells < 0
+  ) {
+    throw createCoreError("execution", {
+      code: ErrorCodes.INVALID_PLAN,
+      message: "Split step has invalid minimum-cell constraints",
+      path: splitStep.id,
+      details: buildDynamicResolutionDetails(splitStep, dynamic, context),
+    })
+  }
+
+  if (resolvedPaneCells < minTargetCells + minCreatedCells) {
+    throw createCoreError("execution", {
+      code: ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED,
+      message: "Pane is too small for requested fixed and weighted splits",
+      path: splitStep.id,
+      details: buildDynamicResolutionDetails(splitStep, dynamic, context),
+    })
+  }
+
+  let targetCells: number
+  if (target.kind === "fixed-cells") {
+    targetCells = target.cells
+  } else {
+    if (!Number.isFinite(target.weight) || target.weight <= 0) {
+      throw createCoreError("execution", {
+        code: ErrorCodes.INVALID_PLAN,
+        message: "Split step has invalid weight metadata",
+        path: splitStep.id,
+        details: buildDynamicResolutionDetails(splitStep, dynamic, context),
+      })
+    }
+
+    const availableForWeights = resolvedPaneCells - remainingFixedCells
+    const weightTotal = target.weight + remainingWeight
+    if (!Number.isFinite(weightTotal) || weightTotal <= 0) {
+      throw createCoreError("execution", {
+        code: ErrorCodes.INVALID_PLAN,
+        message: "Split step has invalid dynamic weight totals",
+        path: splitStep.id,
+        details: buildDynamicResolutionDetails(splitStep, dynamic, context),
+      })
+    }
+
+    const rawTarget = Math.round((availableForWeights * target.weight) / weightTotal)
+    const maxTargetCells = resolvedPaneCells - minCreatedCells
+    targetCells = clamp(rawTarget, minTargetCells, maxTargetCells)
+  }
+
+  const createdCells = resolvedPaneCells - targetCells
+
+  if (targetCells < minTargetCells || createdCells < minCreatedCells || targetCells <= 0 || createdCells <= 0) {
+    throw createCoreError("execution", {
+      code: ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED,
+      message: "Unable to resolve split size without violating pane minimums",
+      path: splitStep.id,
+      details: buildDynamicResolutionDetails(splitStep, dynamic, context, {
+        targetCells,
+        createdCells,
+      }),
+    })
+  }
+
+  return {
+    mode: "cells",
+    cells: String(createdCells),
+    targetCells,
+    createdCells,
+  }
+}
+
+export const resolveSplitPercentage = (step: CommandStep): string => {
+  const resolved = resolveSplitSize(step)
+  if (resolved.mode === "percent") {
+    return resolved.percentage
+  }
+
+  const splitStep = asSplitStep(step, "percentage")
   throw createCoreError("execution", {
     code: ErrorCodes.INVALID_PLAN,
-    message: "Split step missing percentage metadata",
+    message: "Split step uses dynamic sizing and has no percentage value",
     path: splitStep.id,
-    details: { percentage: splitStep.percentage },
+    details: { splitSizing: splitStep.splitSizing },
   })
 }
 
 const clampSplitPercentage = (value: number): number => {
   return Math.min(99, Math.max(1, Math.round(value)))
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(max, Math.max(min, value))
+}
+
+const buildDynamicResolutionDetails = (
+  splitStep: SplitCommandStep,
+  splitSizing: Extract<SplitSizing, { mode: "dynamic-cells" }>,
+  context: SplitSizeResolutionContext,
+  extra: Readonly<Record<string, unknown>> = {},
+): Readonly<Record<string, unknown>> => {
+  return {
+    stepId: splitStep.id,
+    paneId: context.paneId,
+    paneCells: context.paneCells,
+    targetSpec: splitSizing.target,
+    remainingFixedCells: splitSizing.remainingFixedCells,
+    remainingWeight: splitSizing.remainingWeight,
+    remainingWeightPaneCount: splitSizing.remainingWeightPaneCount,
+    requiredVersion: context.requiredVersion,
+    detectedVersion: context.detectedVersion,
+    rawPaneRecord: context.rawPaneRecord,
+    ...extra,
+  }
 }

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -33,7 +33,7 @@ describe("Zod schema validation", () => {
     it("validates valid split container definition", () => {
       const validPane: Pane = {
         type: "horizontal",
-        ratio: [60, 40],
+        ratio: ["60c", 40],
         panes: [{ name: "left" }, { name: "right" }],
       }
 
@@ -57,6 +57,20 @@ describe("Zod schema validation", () => {
 
       const result = PaneSchema.safeParse(nestedPane)
       expect(result.success).toBe(true)
+    })
+
+    it("rejects fixed-cells-only ratio", () => {
+      const invalidPane = {
+        type: "horizontal",
+        ratio: ["40c", "20c"],
+        panes: [{ name: "left" }, { name: "right" }],
+      }
+
+      const result = validatePane(invalidPane)
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toContain("ratio must include at least one numeric weight")
+      }
     })
 
     it("rejects invalid type value", () => {
@@ -91,7 +105,7 @@ describe("Zod schema validation", () => {
     it("validates valid layout definition", () => {
       const validLayout: Layout = {
         type: "vertical",
-        ratio: [70, 30],
+        ratio: ["90c", 30],
         panes: [{ name: "main", command: "nvim" }, { name: "terminal" }],
       }
 
@@ -106,6 +120,18 @@ describe("Zod schema validation", () => {
       }
 
       const result = LayoutSchema.safeParse(invalidLayout)
+      expect(result.success).toBe(false)
+    })
+
+    it("rejects invalid ratio suffix values", () => {
+      const result = validatePreset({
+        name: "Invalid ratio suffix",
+        layout: {
+          type: "horizontal",
+          ratio: ["90", 1],
+          panes: [{ name: "left" }, { name: "right" }],
+        },
+      })
       expect(result.success).toBe(false)
     })
   })

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -33,6 +33,11 @@ const hasNumericWeight = (ratio: ReadonlyArray<number | string>): boolean => {
   return ratio.some((value) => typeof value === "number")
 }
 
+export const LayoutIssueParamCodes = {
+  RATIO_LENGTH_MISMATCH: "RATIO_LENGTH_MISMATCH",
+  RATIO_WEIGHT_MISSING: "RATIO_WEIGHT_MISSING",
+} as const
+
 // Terminal pane schema
 const TerminalPaneSchema = z
   .object({
@@ -59,9 +64,11 @@ const SplitPaneSchema: z.ZodType<unknown> = z.lazy(() =>
     .strict()
     .refine((data) => data.ratio.length === data.panes.length, {
       message: "Number of elements in ratio array does not match number of elements in panes array",
+      params: { code: LayoutIssueParamCodes.RATIO_LENGTH_MISMATCH },
     })
     .refine((data) => hasNumericWeight(data.ratio), {
       message: "ratio must include at least one numeric weight",
+      params: { code: LayoutIssueParamCodes.RATIO_WEIGHT_MISSING },
     }),
 )
 
@@ -77,9 +84,11 @@ export const LayoutSchema = z
   })
   .refine((data) => data.ratio.length === data.panes.length, {
     message: "Number of elements in ratio array does not match number of elements in panes array",
+    params: { code: LayoutIssueParamCodes.RATIO_LENGTH_MISMATCH },
   })
   .refine((data) => hasNumericWeight(data.ratio), {
     message: "ratio must include at least one numeric weight",
+    params: { code: LayoutIssueParamCodes.RATIO_WEIGHT_MISSING },
   })
 
 // Preset schema definition

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -22,6 +22,17 @@ const SelectorDefaultsSchema = z
   })
   .strict()
 
+const RatioValueSchema = z.union([
+  z.number().positive(),
+  z.string().regex(/^[1-9][0-9]*c$/, {
+    message: 'ratio value must be a positive number or "<positive-integer>c"',
+  }),
+])
+
+const hasNumericWeight = (ratio: ReadonlyArray<number | string>): boolean => {
+  return ratio.some((value) => typeof value === "number")
+}
+
 // Terminal pane schema
 const TerminalPaneSchema = z
   .object({
@@ -42,12 +53,15 @@ const SplitPaneSchema: z.ZodType<unknown> = z.lazy(() =>
   z
     .object({
       type: z.enum(["horizontal", "vertical"]),
-      ratio: z.array(z.number().positive()).min(1),
+      ratio: z.array(RatioValueSchema).min(1),
       panes: z.array(PaneSchema).min(1),
     })
     .strict()
     .refine((data) => data.ratio.length === data.panes.length, {
       message: "Number of elements in ratio array does not match number of elements in panes array",
+    })
+    .refine((data) => hasNumericWeight(data.ratio), {
+      message: "ratio must include at least one numeric weight",
     }),
 )
 
@@ -58,11 +72,14 @@ export const PaneSchema: z.ZodType<unknown> = z.lazy(() => z.union([SplitPaneSch
 export const LayoutSchema = z
   .object({
     type: z.enum(["horizontal", "vertical"]),
-    ratio: z.array(z.number().positive()).min(1),
+    ratio: z.array(RatioValueSchema).min(1),
     panes: z.array(PaneSchema).min(1),
   })
   .refine((data) => data.ratio.length === data.panes.length, {
     message: "Number of elements in ratio array does not match number of elements in panes array",
+  })
+  .refine((data) => hasNumericWeight(data.ratio), {
+    message: "ratio must include at least one numeric weight",
   })
 
 // Preset schema definition

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -185,4 +185,20 @@ describe("error helpers", () => {
     expect(unsupportedWithoutVersionsFormatted).toContain("Error: wezterm version")
     expect(unsupportedWithoutVersionsFormatted).toContain("Unsupported wezterm version detected.")
   })
+
+  it("formats split size resolution errors with pane/version details", () => {
+    const error = createEnvironmentError("split size failed", ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED, {
+      paneId: "100",
+      paneCells: 80,
+      detectedVersion: "20240203-110809",
+      requiredVersion: "20220624-141144-bd1b7c5d",
+    })
+
+    const formatted = formatError(error)
+    expect(formatted).toContain("Unable to resolve split size from pane dimensions.")
+    expect(formatted).toContain("Pane ID: 100")
+    expect(formatted).toContain("Pane cells: 80")
+    expect(formatted).toContain("Detected version: 20240203-110809")
+    expect(formatted).toContain("Required version: 20220624-141144-bd1b7c5d")
+  })
 })

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -25,6 +25,7 @@ export const ErrorCodes = {
   WEZTERM_NOT_FOUND: "WEZTERM_NOT_FOUND",
   UNSUPPORTED_WEZTERM_VERSION: "UNSUPPORTED_WEZTERM_VERSION",
   USER_CANCELLED: "USER_CANCELLED",
+  SPLIT_SIZE_RESOLUTION_FAILED: "SPLIT_SIZE_RESOLUTION_FAILED",
 } as const
 
 const createBaseError = (
@@ -160,6 +161,26 @@ const formatters: Record<string, (error: VDELayoutError) => string> = {
     }
     if (requiredVersion) {
       lines.push(`Required version: ${requiredVersion} or higher`)
+    }
+    return lines.join("\n")
+  },
+  [ErrorCodes.SPLIT_SIZE_RESOLUTION_FAILED]: (error) => {
+    const paneId = typeof error.details.paneId === "string" ? error.details.paneId : ""
+    const paneCells = typeof error.details.paneCells === "number" ? String(error.details.paneCells) : ""
+    const detected = typeof error.details.detectedVersion === "string" ? error.details.detectedVersion : ""
+    const required = typeof error.details.requiredVersion === "string" ? error.details.requiredVersion : ""
+    const lines = ["", "Unable to resolve split size from pane dimensions."]
+    if (paneId) {
+      lines.push(`Pane ID: ${paneId}`)
+    }
+    if (paneCells) {
+      lines.push(`Pane cells: ${paneCells}`)
+    }
+    if (detected) {
+      lines.push(`Detected version: ${detected}`)
+    }
+    if (required) {
+      lines.push(`Required version: ${required}`)
     }
     return lines.join("\n")
   },


### PR DESCRIPTION
## Summary
- ratio に `number | "<n>c"` を導入し、固定セル + 比率の混在レイアウトをサポート
- 先に固定セルを差し引き、残り領域を比率で再配分する dynamic-cells 解決ロジックを実装
- tmux/wezterm の実行・dry-run・パーサーを拡張し、エラー詳細とREADME/サンプル/テストを更新

## Verification
- pnpm run ci


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support mixed ratio syntax: fixed-cell entries plus weighted values (e.g., ["90c", 2]) for precise pane sizing.
  * Dry-run and execution use terminal-aware sizing so splits can use actual cell counts when available (falls back to a dynamic placeholder).

* **Bug Fixes**
  * Better validation and clearer errors for invalid or infeasible ratio configs (e.g., fixed-only or malformed entries).

* **Documentation**
  * Updated examples and presets to show the new ratio/fixed-cell behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->