### PR TITLE
feat: protect sidebar panes and add hooks.afterApply

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ presets:
       # see Layout Structure
     command: "htop"             # optional; used when layout is omitted
     hooks:                      # optional; see Hooks
-      afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}"
+      afterApply: "vde-tmux-sidebar open"
 ```
 
 ### Defaults Structure
@@ -189,27 +189,29 @@ presets:
 - Coordinate tasks across multiple panes within your preset configuration
 
 ### Hooks
-`hooks.afterApply` runs an arbitrary host command once, after a preset has been applied successfully. It is a general-purpose hook (not specific to any tool); one intended use is opening a sidebar tool such as [vde-tmux-sidebar](https://github.com/yuki-yano/vde-tmux-sidebar) once the layout has finished building.
+`hooks.afterApply` runs an arbitrary host command once, after a preset has been applied successfully. It is a general-purpose hook (not specific to any tool); one intended use is idempotently opening a sidebar tool such as [vde-tmux-sidebar](https://github.com/yuki-yano/vde-tmux-sidebar) once the layout has finished building — the sidebar itself is managed by that separate tool, not defined as a layout pane in vde-layout's preset.
 
 ```yaml
 presets:
-  dev-with-sidebar:
-    name: Dev with Sidebar
+  dev:
+    name: Dev
     layout:
       type: horizontal
-      ratio: [1, 3]
+      ratio: [3, 1]
       panes:
-        - name: sidebar
         - name: editor
+          command: nvim
           focus: true
+        - name: repl
+          command: node
     hooks:
-      afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}"
+      afterApply: "vde-tmux-sidebar open"
 ```
 
 - Runs exactly once, only after `applyPlan` succeeds; it never runs during `--dry-run` (dry-run instead prints the unresolved command as a planned step).
 - Executes as a host shell command (equivalent to `sh -c "<command>"`, so pipes/args/redirection work) in the directory vde-layout was invoked from (the CLI's `cwd`), not inside any particular tmux pane.
 - If the command fails, or if a template token inside it cannot be resolved, vde-layout logs a warning and the preset apply is still reported as successful (exit code is unaffected).
-- Template tokens are supported: `{{pane_id:<name>}}` resolves as usual. Because the hook doesn't run "in" any specific pane, `{{this_pane}}` and `{{focus_pane}}` both resolve to the pane that ended up focused after the apply.
+- Template tokens are supported, but `{{pane_id:<name>}}` only resolves against the pane names created by *this apply's* own `layout` — it cannot address an existing external pane such as a sidebar. This is especially easy to get wrong in `current-window` mode: the reused current pane is bound to the layout tree's first pane name, so a hook that tries `{{pane_id:sidebar}}` for a preset pane named `sidebar` would silently resolve to the current pane, not the real sidebar. Because the hook doesn't run "in" any specific pane, `{{this_pane}}` and `{{focus_pane}}` both resolve to the pane that ended up focused after the apply.
 
 ### Ephemeral Panes
 Ephemeral panes automatically close after their command completes. This is useful for one-time tasks like builds, tests, or initialization scripts.

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ presets:
 - Runs exactly once, only after `applyPlan` succeeds; it never runs during `--dry-run` (dry-run instead prints the unresolved command as a planned step).
 - Executes as a host shell command (equivalent to `sh -c "<command>"`, so pipes/args/redirection work) in the directory vde-layout was invoked from (the CLI's `cwd`), not inside any particular tmux pane.
 - If the command fails, or if a template token inside it cannot be resolved, vde-layout logs a warning and the preset apply is still reported as successful (exit code is unaffected).
+- The command is killed and treated as a failure (logged as a warning) if it runs for longer than 30 seconds.
 - Template tokens are supported, but `{{pane_id:<name>}}` only resolves against the pane names created by *this apply's* own `layout` — it cannot address an existing external pane such as a sidebar. This is especially easy to get wrong in `current-window` mode: the reused current pane is bound to the layout tree's first pane name, so a hook that tries `{{pane_id:sidebar}}` for a preset pane named `sidebar` would silently resolve to the current pane, not the real sidebar. Because the hook doesn't run "in" any specific pane, `{{this_pane}}` and `{{focus_pane}}` both resolve to the pane that ended up focused after the apply.
 
 ### Ephemeral Panes

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ presets:
     layout:                     # optional; omit for single command presets
       # see Layout Structure
     command: "htop"             # optional; used when layout is omitted
+    hooks:                      # optional; see Hooks
+      afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}"
 ```
 
 ### Defaults Structure
@@ -185,6 +187,29 @@ presets:
 - Send commands to other panes: `tmux send-keys -t {{pane_id:editor}} "npm test" Enter`
 - Display pane information for debugging: `echo "Current: {{this_pane}}, Focus: {{focus_pane}}"`
 - Coordinate tasks across multiple panes within your preset configuration
+
+### Hooks
+`hooks.afterApply` runs an arbitrary host command once, after a preset has been applied successfully. It is a general-purpose hook (not specific to any tool); one intended use is opening a sidebar tool such as [vde-tmux-sidebar](https://github.com/yuki-yano/vde-tmux-sidebar) once the layout has finished building.
+
+```yaml
+presets:
+  dev-with-sidebar:
+    name: Dev with Sidebar
+    layout:
+      type: horizontal
+      ratio: [1, 3]
+      panes:
+        - name: sidebar
+        - name: editor
+          focus: true
+    hooks:
+      afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}"
+```
+
+- Runs exactly once, only after `applyPlan` succeeds; it never runs during `--dry-run` (dry-run instead prints the unresolved command as a planned step).
+- Executes as a host shell command (equivalent to `sh -c "<command>"`, so pipes/args/redirection work) in the directory vde-layout was invoked from (the CLI's `cwd`), not inside any particular tmux pane.
+- If the command fails, or if a template token inside it cannot be resolved, vde-layout logs a warning and the preset apply is still reported as successful (exit code is unaffected).
+- Template tokens are supported: `{{pane_id:<name>}}` resolves as usual. Because the hook doesn't run "in" any specific pane, `{{this_pane}}` and `{{focus_pane}}` both resolve to the pane that ended up focused after the apply.
 
 ### Ephemeral Panes
 Ephemeral panes automatically close after their command completes. This is useful for one-time tasks like builds, tests, or initialization scripts.
@@ -255,6 +280,7 @@ presets:
 - Each preset may override the default by specifying its own `windowMode`.
 - CLI flags (`--current-window` / `--new-window`) take highest precedence and override both presets and defaults.
 - When `current-window` mode is used during an actual run, vde-layout prompts for confirmation before closing panes other than the pane running the command. Dry-run mode prints the intended closures without prompting.
+- **Sidebar protection:** panes with the tmux pane user option `@vde_sidebar` set to `1` (as set by tools like [vde-tmux-sidebar](https://github.com/yuki-yano/vde-tmux-sidebar)) are treated as protected sidebar panes in `current-window` mode. They are never killed when reusing the window, and the preset's layout is built in the remaining, non-sidebar area of the window instead of the sidebar pane itself.
 
 
 ## Runtime Behavior

--- a/src/backends/tmux/backend.ts
+++ b/src/backends/tmux/backend.ts
@@ -4,6 +4,7 @@ import { createTmuxExecutor } from "./executor"
 import type { CommandStep, PlanEmission } from "../../core/emitter"
 import { isCoreError } from "../../core/errors"
 import { executePlan } from "../../executor/plan-runner"
+import { SIDEBAR_LIST_PANES_FORMAT } from "../../executor/sidebar-detection"
 import { resolveSplitOrientation as resolveSplitOrientationFromStep, resolveSplitSize } from "../../executor/split-step"
 import { resolveRequiredStepTargetPaneId } from "../../executor/step-target"
 import { createUnsupportedStepKindError } from "../../executor/unsupported-step-kind"
@@ -179,8 +180,74 @@ const resolveInitialTmuxPaneSize = (): PaneDimensions | undefined => {
     return undefined
   }
 
+  const currentPane = queryTmuxCurrentPaneSizeAndSidebarFlag(tmuxPane)
+  if (currentPane === undefined) {
+    return undefined
+  }
+
+  if (!currentPane.isSidebar) {
+    return { cols: currentPane.cols, rows: currentPane.rows }
+  }
+
+  // The current pane is the protected sidebar. Dry-run sizing must reflect the
+  // pane the layout will actually be built from (see plan-runner's split-origin
+  // resolution), not the sidebar itself. A real split is never performed here:
+  // when the window has no other pane yet, sizing is simply left unresolved.
+  const originPaneId = resolveDryRunOriginPaneId()
+  if (originPaneId === undefined) {
+    return undefined
+  }
+
+  return queryTmuxPaneSize(originPaneId)
+}
+
+const queryTmuxCurrentPaneSizeAndSidebarFlag = (
+  paneId: string,
+): { cols: number; rows: number; isSidebar: boolean } | undefined => {
   try {
-    const sizeOutput = execFileSync("tmux", ["display-message", "-p", "-t", tmuxPane, "#{pane_width} #{pane_height}"], {
+    const output = execFileSync(
+      "tmux",
+      ["display-message", "-p", "-t", paneId, "#{pane_width} #{pane_height} #{@vde_sidebar}"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    ).trim()
+    const [colsRaw = "", rowsRaw = "", sidebarFlag = ""] = output.split(/\s+/, 3)
+
+    const cols = Number.parseInt(colsRaw, 10)
+    const rows = Number.parseInt(rowsRaw, 10)
+    if (!Number.isInteger(cols) || cols <= 0 || !Number.isInteger(rows) || rows <= 0) {
+      return undefined
+    }
+    return { cols, rows, isSidebar: sidebarFlag === "1" }
+  } catch {
+    return undefined
+  }
+}
+
+const resolveDryRunOriginPaneId = (): string | undefined => {
+  try {
+    const output = execFileSync("tmux", ["list-panes", "-F", SIDEBAR_LIST_PANES_FORMAT], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+
+    for (const line of output.split("\n")) {
+      const [paneId, sidebarFlag] = line.split("\t")
+      if (typeof paneId === "string" && paneId.trim().length > 0 && sidebarFlag?.trim() !== "1") {
+        return paneId.trim()
+      }
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+const queryTmuxPaneSize = (paneId: string): PaneDimensions | undefined => {
+  try {
+    const sizeOutput = execFileSync("tmux", ["display-message", "-p", "-t", paneId, "#{pane_width} #{pane_height}"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim()

--- a/src/backends/tmux/backend.ts
+++ b/src/backends/tmux/backend.ts
@@ -208,7 +208,7 @@ const resolveInitialTmuxPaneSize = (): PaneDimensions | undefined => {
   // resolution, which applies the same correction when windowMode is
   // "current-window"), not the sidebar itself. A real split is never performed
   // here: when the window has no other pane yet, sizing is simply left unresolved.
-  const originPaneId = resolveDryRunOriginPaneId()
+  const originPaneId = resolveDryRunOriginPaneId(tmuxPane)
   if (originPaneId === undefined) {
     return undefined
   }
@@ -241,9 +241,14 @@ const queryTmuxCurrentPaneSizeAndSidebarFlag = (
   }
 }
 
-const resolveDryRunOriginPaneId = (): string | undefined => {
+// `-t targetPaneId` scopes `list-panes` to the window that pane belongs to, so the
+// caller's current pane id must be passed through here too (see the module-level
+// comment above on why this correction is windowMode-independent): without it,
+// this would list tmux's "active" window instead of the one this process is
+// actually running in, which can differ in multi-window/multi-session setups.
+const resolveDryRunOriginPaneId = (targetPaneId: string): string | undefined => {
   try {
-    const output = execFileSync("tmux", ["list-panes", "-F", SIDEBAR_LIST_PANES_FORMAT], {
+    const output = execFileSync("tmux", ["list-panes", "-t", targetPaneId, "-F", SIDEBAR_LIST_PANES_FORMAT], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     })

--- a/src/backends/tmux/backend.ts
+++ b/src/backends/tmux/backend.ts
@@ -168,6 +168,12 @@ const detectTmuxVersion = async (tmuxExecutor: ReturnType<typeof createTmuxExecu
   }
 }
 
+// This is windowMode-independent: it only reads process.env.TMUX_PANE/TMUX and is
+// invoked purely to seed dry-run size estimates, regardless of whether the plan will
+// eventually be applied in "current-window" or "new-window" mode. The sidebar
+// correction below therefore applies unconditionally whenever the process happens to
+// be running with its current pane inside a real tmux sidebar, not just when
+// windowMode is "current-window".
 const resolveInitialTmuxPaneSize = (): PaneDimensions | undefined => {
   const tmuxPane = process.env.TMUX_PANE
   const tmuxSession = process.env.TMUX
@@ -191,8 +197,9 @@ const resolveInitialTmuxPaneSize = (): PaneDimensions | undefined => {
 
   // The current pane is the protected sidebar. Dry-run sizing must reflect the
   // pane the layout will actually be built from (see plan-runner's split-origin
-  // resolution), not the sidebar itself. A real split is never performed here:
-  // when the window has no other pane yet, sizing is simply left unresolved.
+  // resolution, which applies the same correction when windowMode is
+  // "current-window"), not the sidebar itself. A real split is never performed
+  // here: when the window has no other pane yet, sizing is simply left unresolved.
   const originPaneId = resolveDryRunOriginPaneId()
   if (originPaneId === undefined) {
     return undefined

--- a/src/backends/tmux/backend.ts
+++ b/src/backends/tmux/backend.ts
@@ -8,6 +8,7 @@ import { SIDEBAR_LIST_PANES_FORMAT } from "../../executor/sidebar-detection"
 import { resolveSplitOrientation as resolveSplitOrientationFromStep, resolveSplitSize } from "../../executor/split-step"
 import { resolveRequiredStepTargetPaneId } from "../../executor/step-target"
 import { createUnsupportedStepKindError } from "../../executor/unsupported-step-kind"
+import { buildNameToRealIdMap } from "../../utils/template-tokens"
 import type {
   ApplyPlanParameters,
   ApplyPlanResult,
@@ -67,9 +68,16 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
       detectedVersion,
     })
 
+    // The plan runner tracks a virtual-pane-id -> real-pane-id map internally; expose
+    // it (resolved) here so callers such as hooks.afterApply can address panes by
+    // name/focus without knowing tmux's virtual ids. Tests may stub executePlan
+    // without a paneMap, so fall back to an empty one rather than throwing.
+    const paneMap = executionResult.paneMap ?? new Map<string, string>()
+
     return {
       executedSteps: executionResult.executedSteps,
-      focusPaneId: emission.summary.focusPaneId,
+      focusPaneId: paneMap.get(emission.summary.focusPaneId),
+      paneNameToRealId: buildNameToRealIdMap(emission.terminals, paneMap),
     }
   }
 

--- a/src/backends/wezterm/backend.ts
+++ b/src/backends/wezterm/backend.ts
@@ -17,6 +17,7 @@ import { parseWeztermListResult } from "./list-parser"
 import { registerPaneWithAncestors } from "./pane-map"
 import { applyFocusStep, applySplitStep, applyTerminalCommands } from "./step-execution"
 import type { ExecuteWeztermCommand, PaneMap } from "./shared"
+import { buildNameToRealIdMap } from "../../utils/template-tokens"
 
 const ensureVirtualPaneId = (emission: PlanEmission): string => {
   const { initialPaneId } = emission.summary
@@ -151,6 +152,7 @@ export const createWeztermBackend = (context: WeztermTerminalBackendContext): Te
     return {
       executedSteps,
       focusPaneId,
+      paneNameToRealId: buildNameToRealIdMap(emission.terminals, paneMap),
     }
   }
 

--- a/src/cli/after-apply-hook.test.ts
+++ b/src/cli/after-apply-hook.test.ts
@@ -180,6 +180,7 @@ describe("createDefaultRunHostCommand", () => {
     expect(execaMock).toHaveBeenCalledWith("vde-tmux-sidebar open %2 | logger", {
       shell: true,
       cwd: "/workspace",
+      timeout: 30_000,
     })
   })
 })

--- a/src/cli/after-apply-hook.test.ts
+++ b/src/cli/after-apply-hook.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("execa", () => ({
+  execa: vi.fn(),
+}))
+
+import { execa } from "execa"
+import { createDefaultRunHostCommand, runAfterApplyHook } from "./after-apply-hook"
+import type { Logger } from "../utils/logger"
+import { LogLevel } from "../utils/logger"
+
+const execaMock = vi.mocked(execa)
+
+const createMockLogger = (): Logger => {
+  const logger: Logger = {
+    level: LogLevel.INFO,
+    prefix: "",
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    debug: vi.fn(),
+    createChild: vi.fn((): Logger => logger),
+  }
+  return logger
+}
+
+describe("runAfterApplyHook", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("does nothing when no hook command is configured", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: undefined,
+      context: { cwd: "/workspace" },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).not.toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it("resolves {{pane_id:<name>}} tokens before running the host command once", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "vde-tmux-sidebar open {{pane_id:sidebar}}",
+      context: {
+        cwd: "/workspace",
+        focusPaneId: "%0",
+        paneNameToRealId: new Map([["sidebar", "%2"]]),
+      },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).toHaveBeenCalledTimes(1)
+    expect(runHostCommand).toHaveBeenCalledWith("vde-tmux-sidebar open %2", { cwd: "/workspace" })
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it("resolves {{focus_pane}} and {{this_pane}} to the applied focus pane id", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "notify-focus {{focus_pane}} {{this_pane}}",
+      context: { cwd: "/workspace", focusPaneId: "%1" },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).toHaveBeenCalledWith("notify-focus %1 %1", { cwd: "/workspace" })
+  })
+
+  it("warns and skips execution when a template token cannot be resolved", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "vde-tmux-sidebar open {{pane_id:missing}}",
+      context: { cwd: "/workspace", paneNameToRealId: new Map() },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing"))
+  })
+
+  it("warns but does not throw when the host command fails", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {
+      throw new Error("command not found: vde-tmux-sidebar")
+    })
+
+    await expect(
+      runAfterApplyHook({
+        hookCommand: "vde-tmux-sidebar open",
+        context: { cwd: "/workspace" },
+        logger,
+        runHostCommand,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("command not found: vde-tmux-sidebar"))
+  })
+})
+
+describe("createDefaultRunHostCommand", () => {
+  beforeEach(() => {
+    execaMock.mockReset()
+  })
+
+  it("runs the command through the host shell so pipes and arguments work", async () => {
+    execaMock.mockResolvedValue({ stdout: "" } as never)
+    const runHostCommand = createDefaultRunHostCommand()
+
+    await runHostCommand("vde-tmux-sidebar open %2 | logger", { cwd: "/workspace" })
+
+    expect(execaMock).toHaveBeenCalledWith("vde-tmux-sidebar open %2 | logger", {
+      shell: true,
+      cwd: "/workspace",
+    })
+  })
+})

--- a/src/cli/after-apply-hook.test.ts
+++ b/src/cli/after-apply-hook.test.ts
@@ -95,6 +95,57 @@ describe("runAfterApplyHook", () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("missing"))
   })
 
+  it("warns and skips execution when {{focus_pane}} is used but no focus pane id is available", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "notify-focus {{focus_pane}}",
+      context: { cwd: "/workspace" },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("focus pane"))
+  })
+
+  it("warns and skips execution when {{this_pane}} is used but no focus pane id is available", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "notify-focus {{this_pane}}",
+      context: { cwd: "/workspace" },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+  })
+
+  it("logs the resolved command via logger.info before executing it", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "vde-tmux-sidebar open {{pane_id:sidebar}}",
+      context: {
+        cwd: "/workspace",
+        paneNameToRealId: new Map([["sidebar", "%2"]]),
+      },
+      logger,
+      runHostCommand,
+    })
+
+    expect(logger.info).toHaveBeenCalledWith("Executing: vde-tmux-sidebar open %2")
+    const infoOrder = (logger.info as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]
+    const runOrder = runHostCommand.mock.invocationCallOrder[0]
+    expect(infoOrder).toBeLessThan(runOrder as number)
+  })
+
   it("warns but does not throw when the host command fails", async () => {
     const logger = createMockLogger()
     const runHostCommand = vi.fn(async () => {

--- a/src/cli/after-apply-hook.ts
+++ b/src/cli/after-apply-hook.ts
@@ -1,0 +1,75 @@
+import { execa } from "execa"
+import { replaceTemplateTokens, TemplateTokenError } from "../utils/template-tokens"
+import type { Logger } from "../utils/logger"
+
+export type RunHostCommand = (command: string, options: { readonly cwd: string }) => Promise<void>
+
+export type AfterApplyHookContext = {
+  readonly cwd: string
+  readonly focusPaneId?: string
+  readonly paneNameToRealId?: ReadonlyMap<string, string>
+}
+
+type RunAfterApplyHookInput = {
+  readonly hookCommand: string | undefined
+  readonly context: AfterApplyHookContext
+  readonly logger: Logger
+  readonly runHostCommand?: RunHostCommand
+}
+
+/**
+ * Runs the `hooks.afterApply` preset command once, after a preset has been applied
+ * successfully. Failures (token resolution or command execution) are logged as
+ * warnings and never rejected/thrown, so they cannot affect the CLI's exit code -
+ * the preset apply itself has already succeeded by the time this runs.
+ */
+export const runAfterApplyHook = async ({
+  hookCommand,
+  context,
+  logger,
+  runHostCommand = createDefaultRunHostCommand(),
+}: RunAfterApplyHookInput): Promise<void> => {
+  if (typeof hookCommand !== "string" || hookCommand.length === 0) {
+    return
+  }
+
+  let resolvedCommand: string
+  try {
+    resolvedCommand = replaceTemplateTokens({
+      command: hookCommand,
+      // A host-level hook is not "sent" to any particular tmux/wezterm pane the way
+      // a terminal pane command is, so there is no distinct "current pane" for it.
+      // The pane that ends up focused after the layout was applied is the closest
+      // analogue, so {{this_pane}} and {{focus_pane}} intentionally resolve to the
+      // same value here.
+      currentPaneRealId: context.focusPaneId ?? "",
+      focusPaneRealId: context.focusPaneId ?? "",
+      nameToRealIdMap: context.paneNameToRealId ?? new Map<string, string>(),
+    })
+  } catch (error) {
+    const reason = error instanceof TemplateTokenError ? error.message : String(error)
+    logger.warn(`hooks.afterApply skipped: failed to resolve template tokens (${reason})`)
+    return
+  }
+
+  try {
+    await runHostCommand(resolvedCommand, { cwd: context.cwd })
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    logger.warn(`hooks.afterApply failed: ${reason}`)
+  }
+}
+
+/**
+ * Executes the resolved hook command through the host shell (equivalent to
+ * `sh -c <command>`), rather than splitting it into argv the way tmux commands
+ * are executed. hooks.afterApply commands are user-authored, free-form shell
+ * text (e.g. "vde-tmux-sidebar open {{pane_id:sidebar}} | logger") that may rely
+ * on pipes, redirection, or shell expansion, so argv-style execution would break
+ * common use cases.
+ */
+export const createDefaultRunHostCommand = (): RunHostCommand => {
+  return async (command, { cwd }) => {
+    await execa(command, { shell: true, cwd })
+  }
+}

--- a/src/cli/after-apply-hook.ts
+++ b/src/cli/after-apply-hook.ts
@@ -4,6 +4,11 @@ import type { Logger } from "../utils/logger"
 
 export type RunHostCommand = (command: string, options: { readonly cwd: string }) => Promise<void>
 
+// Guards against a hook command that hangs indefinitely (e.g. a misbehaving sidebar
+// tool). A timed-out execution rejects, which is handled the same as any other
+// hook failure below: logged as a warning and never surfaced as a CLI error.
+const AFTER_APPLY_HOOK_TIMEOUT_MS = 30_000
+
 export type AfterApplyHookContext = {
   readonly cwd: string
   readonly focusPaneId?: string
@@ -90,6 +95,6 @@ export const runAfterApplyHook = async ({
  */
 export const createDefaultRunHostCommand = (): RunHostCommand => {
   return async (command, { cwd }) => {
-    await execa(command, { shell: true, cwd })
+    await execa(command, { shell: true, cwd, timeout: AFTER_APPLY_HOOK_TIMEOUT_MS })
   }
 }

--- a/src/cli/after-apply-hook.ts
+++ b/src/cli/after-apply-hook.ts
@@ -17,6 +17,10 @@ type RunAfterApplyHookInput = {
   readonly runHostCommand?: RunHostCommand
 }
 
+// Matches the {{this_pane}}/{{focus_pane}} tokens that this module resolves to
+// context.focusPaneId (see the comment below on why they share one value).
+const FOCUS_PANE_TOKEN_PATTERN = /\{\{(?:this_pane|focus_pane)\}\}/
+
 /**
  * Runs the `hooks.afterApply` preset command once, after a preset has been applied
  * successfully. Failures (token resolution or command execution) are logged as
@@ -30,6 +34,18 @@ export const runAfterApplyHook = async ({
   runHostCommand = createDefaultRunHostCommand(),
 }: RunAfterApplyHookInput): Promise<void> => {
   if (typeof hookCommand !== "string" || hookCommand.length === 0) {
+    return
+  }
+
+  // {{this_pane}}/{{focus_pane}} resolve to context.focusPaneId (see the comment
+  // below), but replaceTemplateTokens substitutes them verbatim even when given an
+  // empty string - it only validates {{pane_id:<name>}} lookups. Treat a missing
+  // focus pane id as an unresolved token here too, rather than silently running the
+  // command with an empty pane id spliced in.
+  if (context.focusPaneId === undefined && FOCUS_PANE_TOKEN_PATTERN.test(hookCommand)) {
+    logger.warn(
+      "hooks.afterApply skipped: failed to resolve template tokens ({{this_pane}}/{{focus_pane}} require a focus pane id, but none was available)",
+    )
     return
   }
 
@@ -51,6 +67,10 @@ export const runAfterApplyHook = async ({
     logger.warn(`hooks.afterApply skipped: failed to resolve template tokens (${reason})`)
     return
   }
+
+  // Mirrors real-executor.ts's "Executing: <command>" log; logger.info is already
+  // gated on --verbose/VDE_VERBOSE by the shared logger implementation.
+  logger.info(`Executing: ${resolvedCommand}`)
 
   try {
     await runHostCommand(resolvedCommand, { cwd: context.cwd })

--- a/src/cli/command-helpers.test.ts
+++ b/src/cli/command-helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import type { DryRunStep } from "../executor/terminal-backend"
-import { buildPresetSource, determineCliWindowMode, renderDryRun } from "./command-helpers"
+import { buildPresetSource, determineCliWindowMode, renderDryRun, renderDryRunHook } from "./command-helpers"
 
 describe("command helpers", () => {
   describe("buildPresetSource", () => {
@@ -68,6 +68,26 @@ describe("command helpers", () => {
       expect(output).toHaveBeenCalledTimes(2)
       expect(output).toHaveBeenNthCalledWith(1, expect.stringContaining("Planned terminal steps (dry-run)"))
       expect(output).toHaveBeenNthCalledWith(2, " 1. [tmux] split root: tmux split-window -h -t root -p 50")
+    })
+  })
+
+  describe("renderDryRunHook", () => {
+    it("renders the unresolved afterApply command as a planned step", () => {
+      const output = vi.fn()
+
+      renderDryRunHook("vde-tmux-sidebar open {{pane_id:sidebar}}", output)
+
+      expect(output).toHaveBeenCalledTimes(2)
+      expect(output).toHaveBeenNthCalledWith(1, expect.stringContaining("Planned hooks (dry-run)"))
+      expect(output).toHaveBeenNthCalledWith(2, " 1. [afterApply] vde-tmux-sidebar open {{pane_id:sidebar}}")
+    })
+
+    it("renders nothing when no afterApply hook is configured", () => {
+      const output = vi.fn()
+
+      renderDryRunHook(undefined, output)
+
+      expect(output).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/cli/command-helpers.ts
+++ b/src/cli/command-helpers.ts
@@ -13,6 +13,20 @@ export const renderDryRun = (
   })
 }
 
+export const renderDryRunHook = (
+  afterApply: string | undefined,
+  output: (message: string) => void = (message): void => console.log(message),
+): void => {
+  if (typeof afterApply !== "string" || afterApply.length === 0) {
+    return
+  }
+
+  // Dry-run has not created any panes, so pane ids aren't known yet; show the raw,
+  // unresolved hook command rather than attempting template token resolution.
+  output(chalk.bold("\nPlanned hooks (dry-run)"))
+  output(` 1. [afterApply] ${afterApply}`)
+}
+
 export const buildPresetSource = (presetName?: string): string => {
   return typeof presetName === "string" && presetName.length > 0 ? `preset://${presetName}` : "preset://default"
 }

--- a/src/cli/preset-execution.test.ts
+++ b/src/cli/preset-execution.test.ts
@@ -8,11 +8,17 @@ import type { CoreBridge } from "./index"
 import type { PresetManager } from "../contracts"
 import type { CommandExecutor } from "../contracts"
 import type { TerminalBackend } from "../executor/terminal-backend"
+import type { CompiledPreset } from "../core/index"
 
 const createTerminalBackendMock = vi.hoisted(() => vi.fn())
+const runAfterApplyHookMock = vi.hoisted(() => vi.fn(async () => {}))
 
 vi.mock("../executor/backend-factory", () => ({
   createTerminalBackend: createTerminalBackendMock,
+}))
+
+vi.mock("./after-apply-hook", () => ({
+  runAfterApplyHook: runAfterApplyHookMock,
 }))
 
 const createMockLogger = (): Logger => {
@@ -48,7 +54,7 @@ const createMockExecutor = (): CommandExecutor => ({
   logCommand: vi.fn(),
 })
 
-const createMockCore = (emission: PlanEmission): CoreBridge => {
+const createMockCore = (emission: PlanEmission, compiledPresetOverrides: Partial<CompiledPreset> = {}): CoreBridge => {
   return {
     compilePreset: vi.fn() as unknown as CoreBridge["compilePreset"],
     compilePresetFromValue: vi.fn(() => ({
@@ -56,6 +62,7 @@ const createMockCore = (emission: PlanEmission): CoreBridge => {
         name: "Development",
         version: "legacy",
         metadata: { source: "preset://dev" },
+        ...compiledPresetOverrides,
       },
     })) as unknown as CoreBridge["compilePresetFromValue"],
     createLayoutPlan: vi.fn(() => ({
@@ -92,6 +99,8 @@ describe("executePreset", () => {
 
   beforeEach(() => {
     createTerminalBackendMock.mockReset()
+    runAfterApplyHookMock.mockReset()
+    runAfterApplyHookMock.mockResolvedValue(undefined)
   })
 
   it("runs dry-run flow and renders backend-provided steps", async () => {
@@ -179,6 +188,7 @@ describe("executePreset", () => {
     expect(backend.getDryRunSteps).not.toHaveBeenCalled()
     expect(backend.applyPlan).toHaveBeenCalledTimes(1)
     expect(logger.info).toHaveBeenCalledWith("Executed 2 tmux steps")
+    expect(runAfterApplyHookMock).not.toHaveBeenCalled()
   })
 
   it("delegates compile/emit failures to pipeline handler", async () => {
@@ -219,5 +229,131 @@ describe("executePreset", () => {
 
     expect(exitCode).toBe(1)
     expect(handlePipelineFailure).toHaveBeenCalledWith(pipelineError)
+  })
+
+  it("runs hooks.afterApply once after a successful apply, passing the resolved pane mapping", async () => {
+    const logger = createMockLogger()
+    const presetManager = createMockPresetManager(basePreset)
+    const core = createMockCore(baseEmission, {
+      hooks: { afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}" },
+    })
+    const executor = createMockExecutor()
+    const paneNameToRealId = new Map([["sidebar", "%2"]])
+    const backend: TerminalBackend = {
+      verifyEnvironment: vi.fn(async () => {}),
+      applyPlan: vi.fn(async () => ({ executedSteps: 2, focusPaneId: "%0", paneNameToRealId })),
+      getDryRunSteps: vi.fn(() => []),
+    }
+    createTerminalBackendMock.mockReturnValue(backend)
+
+    const exitCode = await executePreset({
+      presetName: "dev",
+      options: {
+        verbose: false,
+        dryRun: false,
+        currentWindow: false,
+        newWindow: true,
+      },
+      presetManager,
+      createCommandExecutor: vi.fn(() => executor),
+      core,
+      logger,
+      handleError: vi.fn(() => 1),
+      handlePipelineFailure: vi.fn(() => 1),
+      output: vi.fn(),
+      cwd: "/workspace",
+      env: {},
+    })
+
+    expect(exitCode).toBe(0)
+    expect(runAfterApplyHookMock).toHaveBeenCalledTimes(1)
+    expect(runAfterApplyHookMock).toHaveBeenCalledWith({
+      hookCommand: "vde-tmux-sidebar open {{pane_id:sidebar}}",
+      context: { cwd: "/workspace", focusPaneId: "%0", paneNameToRealId },
+      logger,
+    })
+  })
+
+  it("skips hooks.afterApply during dry-run and renders it as a planned step instead", async () => {
+    const logger = createMockLogger()
+    const presetManager = createMockPresetManager(basePreset)
+    const core = createMockCore(baseEmission, {
+      hooks: { afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}" },
+    })
+    const executor = createMockExecutor()
+    const backend: TerminalBackend = {
+      verifyEnvironment: vi.fn(async () => {}),
+      applyPlan: vi.fn(async () => ({ executedSteps: 0 })),
+      getDryRunSteps: vi.fn(() => []),
+    }
+    createTerminalBackendMock.mockReturnValue(backend)
+    const output = vi.fn()
+
+    const exitCode = await executePreset({
+      presetName: "dev",
+      options: {
+        verbose: false,
+        dryRun: true,
+        currentWindow: false,
+        newWindow: false,
+      },
+      presetManager,
+      createCommandExecutor: vi.fn(() => executor),
+      core,
+      logger,
+      handleError: vi.fn(() => 1),
+      handlePipelineFailure: vi.fn(() => 1),
+      output,
+      cwd: "/workspace",
+      env: {},
+    })
+
+    expect(exitCode).toBe(0)
+    expect(backend.applyPlan).not.toHaveBeenCalled()
+    expect(runAfterApplyHookMock).not.toHaveBeenCalled()
+    expect(output).toHaveBeenCalledWith(expect.stringContaining("Planned hooks (dry-run)"))
+    expect(output).toHaveBeenCalledWith(" 1. [afterApply] vde-tmux-sidebar open {{pane_id:sidebar}}")
+  })
+
+  it("does not run hooks.afterApply when applyPlan fails", async () => {
+    const logger = createMockLogger()
+    const presetManager = createMockPresetManager(basePreset)
+    const core = createMockCore(baseEmission, {
+      hooks: { afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}" },
+    })
+    const executor = createMockExecutor()
+    const applyError = new Error("apply failed")
+    const backend: TerminalBackend = {
+      verifyEnvironment: vi.fn(async () => {}),
+      applyPlan: vi.fn(async () => {
+        throw applyError
+      }),
+      getDryRunSteps: vi.fn(() => []),
+    }
+    createTerminalBackendMock.mockReturnValue(backend)
+    const handlePipelineFailure = vi.fn(() => 1)
+
+    const exitCode = await executePreset({
+      presetName: "dev",
+      options: {
+        verbose: false,
+        dryRun: false,
+        currentWindow: false,
+        newWindow: false,
+      },
+      presetManager,
+      createCommandExecutor: vi.fn(() => executor),
+      core,
+      logger,
+      handleError: vi.fn(() => 1),
+      handlePipelineFailure,
+      output: vi.fn(),
+      cwd: "/workspace",
+      env: {},
+    })
+
+    expect(exitCode).toBe(1)
+    expect(handlePipelineFailure).toHaveBeenCalledWith(applyError)
+    expect(runAfterApplyHookMock).not.toHaveBeenCalled()
   })
 })

--- a/src/cli/preset-execution.ts
+++ b/src/cli/preset-execution.ts
@@ -1,11 +1,13 @@
 import { createTerminalBackend } from "../executor/backend-factory"
 import { resolveTerminalBackendKind } from "../executor/backend-resolver"
 import type { TerminalBackendKind } from "../executor/terminal-backend"
+import type { CompiledPreset } from "../core/index"
 import type { WindowMode } from "../models/types"
 import type { CommandExecutor } from "../contracts"
 import type { PresetManager } from "../contracts"
 import type { Logger } from "../utils/logger"
-import { buildPresetSource, determineCliWindowMode, renderDryRun } from "./command-helpers"
+import { runAfterApplyHook } from "./after-apply-hook"
+import { buildPresetSource, determineCliWindowMode, renderDryRun, renderDryRunHook } from "./command-helpers"
 import type { CoreBridge } from "./core-bridge"
 import { createPaneKillPrompter } from "./user-prompt"
 import { resolveWindowMode } from "./window-mode"
@@ -101,12 +103,15 @@ export const executePreset = async ({
     }
 
     let emission
+    let compiledPreset: CompiledPreset
     try {
-      emission = buildPlanEmission({
+      const built = buildPlanEmission({
         core,
         preset,
         presetName,
       })
+      emission = built.emission
+      compiledPreset = built.compiledPreset
     } catch (error) {
       return handlePipelineFailure(error)
     }
@@ -114,6 +119,7 @@ export const executePreset = async ({
     if (options.dryRun === true) {
       const dryRunSteps = backend.getDryRunSteps(emission)
       renderDryRun(dryRunSteps, output)
+      renderDryRunHook(compiledPreset.hooks?.afterApply, output)
     } else {
       try {
         const executionResult = await backend.applyPlan({
@@ -125,6 +131,19 @@ export const executePreset = async ({
           }),
         })
         logger.info(`Executed ${executionResult.executedSteps} ${backendKind} steps`)
+
+        const afterApplyCommand = compiledPreset.hooks?.afterApply
+        if (afterApplyCommand !== undefined) {
+          await runAfterApplyHook({
+            hookCommand: afterApplyCommand,
+            context: {
+              cwd,
+              focusPaneId: executionResult.focusPaneId,
+              paneNameToRealId: executionResult.paneNameToRealId,
+            },
+            logger,
+          })
+        }
       } catch (error) {
         return handlePipelineFailure(error)
       }
@@ -145,13 +164,17 @@ const buildPlanEmission = ({
   readonly core: CoreBridge
   readonly preset: ReturnType<PresetManager["getDefaultPreset"]>
   readonly presetName?: string
-}): ReturnType<CoreBridge["emitPlan"]> => {
+}): {
+  readonly emission: ReturnType<CoreBridge["emitPlan"]>
+  readonly compiledPreset: CompiledPreset
+} => {
   const compileResult = core.compilePresetFromValue({
     value: preset,
     source: buildPresetSource(presetName),
   })
   const planResult = core.createLayoutPlan({ preset: compileResult.preset })
-  return core.emitPlan({ plan: planResult.plan })
+  const emission = core.emitPlan({ plan: planResult.plan })
+  return { emission, compiledPreset: compileResult.preset }
 }
 
 const resolveWindowName = ({

--- a/src/core/compile.test.ts
+++ b/src/core/compile.test.ts
@@ -203,6 +203,38 @@ layout:
     })
   })
 
+  it("passes through hooks.afterApply into the compiled preset", () => {
+    const result = compilePresetFromValue({
+      source: "tests/hooks-input",
+      value: {
+        name: "hooks-preset",
+        layout: {
+          type: "horizontal",
+          ratio: [1, 1],
+          panes: [{ name: "main" }, { name: "sidebar" }],
+        },
+        hooks: {
+          afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}",
+        },
+      },
+    })
+
+    expect(result.preset.hooks).toEqual({
+      afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}",
+    })
+  })
+
+  it("compiles a preset without hooks to an undefined hooks field", () => {
+    const result = compilePresetFromValue({
+      source: "tests/no-hooks-input",
+      value: {
+        name: "no-hooks-preset",
+      },
+    })
+
+    expect(result.preset.hooks).toBeUndefined()
+  })
+
   it("converts mixed ratio entries into weight/fixed-cells", () => {
     const result = compilePresetFromValue({
       source: "tests/value-input-mixed-ratio",

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -44,11 +44,16 @@ type CompiledPresetMetadata = {
   readonly source: string
 }
 
+export type CompiledPresetHooks = {
+  readonly afterApply?: string
+}
+
 export type CompiledPreset = {
   readonly name: string
   readonly version: string
   readonly command?: string
   readonly layout?: CompiledLayoutNode
+  readonly hooks?: CompiledPresetHooks
   readonly metadata: CompiledPresetMetadata
 }
 
@@ -107,9 +112,20 @@ const compilePresetValue = ({ value, source }: CompilePresetFromValueInput): Com
       version: "legacy",
       command: typeof parsed.command === "string" ? parsed.command : undefined,
       layout: layout ?? undefined,
+      hooks: parseHooks(parsed.hooks),
       metadata: { source },
     },
   }
+}
+
+const parseHooks = (hooks: unknown): CompiledPresetHooks | undefined => {
+  if (!isRecord(hooks)) {
+    return undefined
+  }
+
+  const afterApply = typeof hooks.afterApply === "string" && hooks.afterApply.length > 0 ? hooks.afterApply : undefined
+
+  return afterApply === undefined ? undefined : { afterApply }
 }
 
 const validateLayoutDefinition = (

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,6 +9,7 @@ export type {
   CompilePresetFromValueInput,
   CompilePresetSuccess,
   CompiledPreset,
+  CompiledPresetHooks,
   CompiledRatioEntry,
 } from "./compile"
 export type { CreateLayoutPlanSuccess, LayoutPlan, PlanNode } from "./planner"

--- a/src/executor/mock-executor.test.ts
+++ b/src/executor/mock-executor.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { createMockExecutor } from "./mock-executor"
+
+describe("createMockExecutor protected panes", () => {
+  it("reports pane user option values via the sidebar list-panes format", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0", "%1", "%2"])
+    executor.setMockProtectedPaneIds(["%1"])
+
+    const output = await executor.execute(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+
+    expect(output).toBe("%0\t\n%1\t1\n%2\t")
+  })
+
+  it("keeps protected panes alive when kill-pane -a targets another pane", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0", "%1", "%2"])
+    executor.setMockProtectedPaneIds(["%1"])
+
+    await executor.execute(["kill-pane", "-a", "-t", "%0"])
+
+    expect(executor.getPaneIds()).toEqual(["%0", "%1"])
+  })
+
+  it("still collapses to the target pane when no panes are protected", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0", "%1", "%2"])
+
+    await executor.execute(["kill-pane", "-a", "-t", "%0"])
+
+    expect(executor.getPaneIds()).toEqual(["%0"])
+  })
+})

--- a/src/executor/mock-executor.ts
+++ b/src/executor/mock-executor.ts
@@ -8,6 +8,7 @@ export type MockExecutor = CommandExecutor &
     readonly clearExecutedCommands: () => void
     readonly setMockPaneIds: (paneIds: string[]) => void
     readonly getPaneIds: () => string[]
+    readonly setMockProtectedPaneIds: (paneIds: string[]) => void
   }
 
 const parseCommand = (commandOrArgs: string | string[]): string[] => {
@@ -30,6 +31,7 @@ const toCommandString = (args: string[]): string => {
 export const createMockExecutor = (): MockExecutor => {
   let mockPaneCounter = 0
   let mockPaneIds: string[] = ["%0"]
+  let mockProtectedPaneIds: string[] = []
   let executedCommands: string[][] = []
 
   const execute = async (commandOrArgs: string | string[]): Promise<string> => {
@@ -58,18 +60,46 @@ export const createMockExecutor = (): MockExecutor => {
       }
     }
 
+    // The two list-panes formats below are matched by exact string equality on the
+    // -F argument, so at most one of these branches ever applies to a given call.
+    if (args.includes("list-panes") && args.includes("#{pane_id}\t#{@vde_sidebar}")) {
+      const protectedPaneIds = new Set(mockProtectedPaneIds)
+      return mockPaneIds.map((paneId) => `${paneId}\t${protectedPaneIds.has(paneId) ? "1" : ""}`).join("\n")
+    }
+
     if (args.includes("list-panes") && args.includes("#{pane_id}")) {
       return mockPaneIds.join("\n")
     }
 
     if (args[0] === "kill-pane" && args.includes("-a")) {
+      // NOTE: Real tmux's `kill-pane -a -t <target>` kills every other pane in the
+      // window, including sidebar panes. This mock deliberately diverges by keeping
+      // mockProtectedPaneIds alive so tests can simulate protection, but production
+      // code must not rely on `kill-pane -a` alone to spare the sidebar: it has to
+      // compute the kill target set explicitly via classifyWindowPanes and kill
+      // non-sidebar panes individually (see plan.md Step 1-4).
       const targetIndex = args.indexOf("-t")
       const targetPane =
         (targetIndex >= 0 && targetIndex + 1 < args.length ? args[targetIndex + 1] : mockPaneIds[0]) ?? "%0"
-      mockPaneIds = [targetPane]
+      const survivingPaneIds = mockPaneIds.filter(
+        (paneId) => paneId === targetPane || mockProtectedPaneIds.includes(paneId),
+      )
+      mockPaneIds = survivingPaneIds.includes(targetPane) ? survivingPaneIds : [targetPane, ...survivingPaneIds]
       const parsedCounter = Number(targetPane.replace("%", ""))
       if (!Number.isNaN(parsedCounter)) {
         mockPaneCounter = parsedCounter
+      }
+      return ""
+    }
+
+    if (args[0] === "kill-pane") {
+      // Individual `kill-pane -t <target>` (no `-a`): only the named pane is
+      // removed, matching real tmux. Production code relies on this to close
+      // non-sidebar panes one at a time (see plan.md Step 1-4).
+      const targetIndex = args.indexOf("-t")
+      const targetPane = targetIndex >= 0 && targetIndex + 1 < args.length ? args[targetIndex + 1] : undefined
+      if (typeof targetPane === "string") {
+        mockPaneIds = mockPaneIds.filter((paneId) => paneId !== targetPane)
       }
       return ""
     }
@@ -107,6 +137,9 @@ export const createMockExecutor = (): MockExecutor => {
     },
     getPaneIds(): string[] {
       return mockPaneIds
+    },
+    setMockProtectedPaneIds(paneIds: string[]): void {
+      mockProtectedPaneIds = [...paneIds]
     },
     isInTmuxSession,
     async verifyTmuxEnvironment(): Promise<void> {

--- a/src/executor/mock-executor.ts
+++ b/src/executor/mock-executor.ts
@@ -108,6 +108,12 @@ export const createMockExecutor = (): MockExecutor => {
       mockPaneCounter += 1
       const newPaneId = `%${mockPaneCounter}`
       mockPaneIds = [...mockPaneIds, newPaneId]
+
+      // `-P -F "#{pane_id}"` asks tmux to print the newly created pane id, matching
+      // real tmux's split-window behavior (see splitPaneBesideSidebar).
+      if (args.includes("-P") && args.includes("#{pane_id}")) {
+        return newPaneId
+      }
     }
 
     return ""

--- a/src/executor/plan-runner.test.ts
+++ b/src/executor/plan-runner.test.ts
@@ -187,8 +187,8 @@ describe("executePlan", () => {
     expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%3"], dryRun: true })
 
     const commands = executor.getExecutedCommands()
-    expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}"])
-    expect(commands[1]).toEqual(["kill-pane", "-a", "-t", "%2"])
+    expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+    expect(commands[1]).toEqual(["kill-pane", "-t", "%3"])
     expect(commands.find((cmd) => cmd[0] === "new-window")).toBeUndefined()
 
     if (originalPane === undefined) {
@@ -244,12 +244,115 @@ describe("executePlan", () => {
     ).rejects.toMatchObject({ code: ErrorCodes.USER_CANCELLED })
 
     const commands = executor.getExecutedCommands()
-    expect(commands).toEqual([["list-panes", "-F", "#{pane_id}"]])
+    expect(commands).toEqual([["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
 
     if (originalPane === undefined) {
       delete process.env.TMUX_PANE
     } else {
       process.env.TMUX_PANE = originalPane
+    }
+  })
+
+  it("excludes sidebar panes from the kill target and closes remaining panes individually", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%2", "%3", "%4"])
+    executor.setMockProtectedPaneIds(["%4"])
+    const originalPane = process.env.TMUX_PANE
+    process.env.TMUX_PANE = "%2"
+    const onConfirmKill = vi.fn().mockResolvedValue(true)
+
+    try {
+      const result = await executePlan({
+        emission: baseEmission,
+        executor,
+        windowMode: "current-window",
+        onConfirmKill,
+      })
+
+      expect(result.executedSteps).toBe(2)
+      expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%3"], dryRun: true })
+
+      const commands = executor.getExecutedCommands()
+      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[1]).toEqual(["kill-pane", "-t", "%3"])
+      expect(commands).not.toContainEqual(["kill-pane", "-t", "%4"])
+      expect(commands.some((cmd) => cmd[0] === "kill-pane" && cmd.includes("-a"))).toBe(false)
+    } finally {
+      if (originalPane === undefined) {
+        delete process.env.TMUX_PANE
+      } else {
+        process.env.TMUX_PANE = originalPane
+      }
+    }
+  })
+
+  it("uses the first normal pane as the split origin when the current pane is the sidebar", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%2", "%3", "%4"])
+    executor.setMockProtectedPaneIds(["%2"])
+    const originalPane = process.env.TMUX_PANE
+    process.env.TMUX_PANE = "%2"
+    const onConfirmKill = vi.fn().mockResolvedValue(true)
+
+    try {
+      const result = await executePlan({
+        emission: baseEmission,
+        executor,
+        windowMode: "current-window",
+        onConfirmKill,
+      })
+
+      expect(result.executedSteps).toBe(2)
+      expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%4"], dryRun: true })
+
+      const commands = executor.getExecutedCommands()
+      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[1]).toEqual(["kill-pane", "-t", "%4"])
+      // The layout is built from the resolved origin pane (%3), never the sidebar (%2).
+      expect(commands).toContainEqual(["split-window", "-h", "-t", "%3", "-p", "50"])
+      expect(commands).toContainEqual(["select-pane", "-t", "%3"])
+      expect(commands.some((cmd) => cmd.includes("%2"))).toBe(false)
+    } finally {
+      if (originalPane === undefined) {
+        delete process.env.TMUX_PANE
+      } else {
+        process.env.TMUX_PANE = originalPane
+      }
+    }
+  })
+
+  it("splits a pane beside the sidebar as the origin when the window has only the sidebar pane", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%9"])
+    executor.setMockProtectedPaneIds(["%9"])
+    const originalPane = process.env.TMUX_PANE
+    process.env.TMUX_PANE = "%9"
+    const onConfirmKill = vi.fn().mockResolvedValue(true)
+
+    try {
+      const result = await executePlan({
+        emission: baseEmission,
+        executor,
+        windowMode: "current-window",
+        onConfirmKill,
+      })
+
+      expect(result.executedSteps).toBe(2)
+      expect(onConfirmKill).not.toHaveBeenCalled()
+
+      const commands = executor.getExecutedCommands()
+      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[1]).toEqual(["split-window", "-h", "-t", "%9"])
+      expect(commands[2]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands.some((cmd) => cmd[0] === "kill-pane")).toBe(false)
+      // The newly split pane (%1) becomes the origin for the rest of the layout.
+      expect(commands).toContainEqual(["split-window", "-h", "-t", "%1", "-p", "50"])
+    } finally {
+      if (originalPane === undefined) {
+        delete process.env.TMUX_PANE
+      } else {
+        process.env.TMUX_PANE = originalPane
+      }
     }
   })
 
@@ -723,8 +826,8 @@ describe("executePlan", () => {
       expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%1"], dryRun: true })
 
       const commands = executor.getExecutedCommands()
-      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}"])
-      expect(commands[1]).toEqual(["kill-pane", "-a", "-t", "%0"])
+      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[1]).toEqual(["kill-pane", "-t", "%1"])
     } finally {
       if (originalPane === undefined) {
         delete process.env.TMUX_PANE
@@ -759,8 +862,8 @@ describe("executePlan", () => {
 
       const commands = executor.getExecutedCommands()
       expect(commands[0]).toEqual(["display-message", "-p", "#{pane_id}"])
-      expect(commands[1]).toEqual(["list-panes", "-F", "#{pane_id}"])
-      expect(commands[2]).toEqual(["kill-pane", "-a", "-t", "%9"])
+      expect(commands[1]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[2]).toEqual(["kill-pane", "-t", "%10"])
     } finally {
       if (originalPane === undefined) {
         delete process.env.TMUX_PANE

--- a/src/executor/plan-runner.test.ts
+++ b/src/executor/plan-runner.test.ts
@@ -197,7 +197,7 @@ describe("executePlan", () => {
     expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%3"], dryRun: true })
 
     const commands = executor.getExecutedCommands()
-    expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+    expect(commands[0]).toEqual(["list-panes", "-t", "%2", "-F", "#{pane_id}\t#{@vde_sidebar}"])
     expect(commands[1]).toEqual(["kill-pane", "-t", "%3"])
     expect(commands.find((cmd) => cmd[0] === "new-window")).toBeUndefined()
 
@@ -254,7 +254,7 @@ describe("executePlan", () => {
     ).rejects.toMatchObject({ code: ErrorCodes.USER_CANCELLED })
 
     const commands = executor.getExecutedCommands()
-    expect(commands).toEqual([["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
+    expect(commands).toEqual([["list-panes", "-t", "%2", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
 
     if (originalPane === undefined) {
       delete process.env.TMUX_PANE
@@ -283,7 +283,7 @@ describe("executePlan", () => {
       expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%3"], dryRun: true })
 
       const commands = executor.getExecutedCommands()
-      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[0]).toEqual(["list-panes", "-t", "%2", "-F", "#{pane_id}\t#{@vde_sidebar}"])
       expect(commands[1]).toEqual(["kill-pane", "-t", "%3"])
       expect(commands).not.toContainEqual(["kill-pane", "-t", "%4"])
       expect(commands.some((cmd) => cmd[0] === "kill-pane" && cmd.includes("-a"))).toBe(false)
@@ -316,12 +316,15 @@ describe("executePlan", () => {
       expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%4"], dryRun: true })
 
       const commands = executor.getExecutedCommands()
-      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[0]).toEqual(["list-panes", "-t", "%2", "-F", "#{pane_id}\t#{@vde_sidebar}"])
       expect(commands[1]).toEqual(["kill-pane", "-t", "%4"])
       // The layout is built from the resolved origin pane (%3), never the sidebar (%2).
       expect(commands).toContainEqual(["split-window", "-h", "-t", "%3", "-p", "50"])
       expect(commands).toContainEqual(["select-pane", "-t", "%3"])
-      expect(commands.some((cmd) => cmd.includes("%2"))).toBe(false)
+      // %2 (the sidebar) is only ever referenced as the `-t` scope for the initial
+      // list-panes classification query, never as the target of a pane-mutating
+      // command (kill-pane/split-window/select-pane).
+      expect(commands.some((cmd) => cmd[0] !== "list-panes" && cmd.includes("%2"))).toBe(false)
     } finally {
       if (originalPane === undefined) {
         delete process.env.TMUX_PANE
@@ -351,9 +354,14 @@ describe("executePlan", () => {
       expect(onConfirmKill).not.toHaveBeenCalled()
 
       const commands = executor.getExecutedCommands()
-      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
-      expect(commands[1]).toEqual(["split-window", "-h", "-t", "%9"])
-      expect(commands[2]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[0]).toEqual(["list-panes", "-t", "%9", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      // The new pane's id is read directly from split-window's `-P -F` stdout, rather
+      // than diffing a follow-up list-panes call against the pre-split pane set.
+      expect(commands[1]).toEqual(["split-window", "-h", "-P", "-F", "#{pane_id}", "-t", "%9"])
+      // No follow-up sidebar-classification list-panes call is issued after the
+      // split; the next list-panes call (index 2) belongs to executeSplitStep's own
+      // before/after pane diffing for the emitted layout split.
+      expect(commands[2]).toEqual(["list-panes", "-F", "#{pane_id}"])
       expect(commands.some((cmd) => cmd[0] === "kill-pane")).toBe(false)
       // The newly split pane (%1) becomes the origin for the rest of the layout.
       expect(commands).toContainEqual(["split-window", "-h", "-t", "%1", "-p", "50"])
@@ -411,9 +419,13 @@ describe("executePlan", () => {
         execute: vi.fn(async (command: string | string[]) => {
           const args = typeof command === "string" ? command.split(" ").slice(1) : command
           if (args[0] === "list-panes") {
-            // Always reports only the sidebar pane, simulating a split that never
-            // produced a new (or newly-visible) normal pane.
             return "%9\t1"
+          }
+          if (args[0] === "split-window") {
+            // Simulates tmux's `-P -F "#{pane_id}"` producing blank/unusable stdout
+            // (e.g. an unexpected tmux version or output format), so plan-runner has
+            // no pane id to read the new pane from.
+            return "   "
           }
           return ""
         }),
@@ -907,7 +919,7 @@ describe("executePlan", () => {
       expect(onConfirmKill).toHaveBeenCalledWith({ panesToClose: ["%1"], dryRun: true })
 
       const commands = executor.getExecutedCommands()
-      expect(commands[0]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[0]).toEqual(["list-panes", "-t", "%0", "-F", "#{pane_id}\t#{@vde_sidebar}"])
       expect(commands[1]).toEqual(["kill-pane", "-t", "%1"])
     } finally {
       if (originalPane === undefined) {
@@ -943,7 +955,7 @@ describe("executePlan", () => {
 
       const commands = executor.getExecutedCommands()
       expect(commands[0]).toEqual(["display-message", "-p", "#{pane_id}"])
-      expect(commands[1]).toEqual(["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"])
+      expect(commands[1]).toEqual(["list-panes", "-t", "%9", "-F", "#{pane_id}\t#{@vde_sidebar}"])
       expect(commands[2]).toEqual(["kill-pane", "-t", "%10"])
     } finally {
       if (originalPane === undefined) {

--- a/src/executor/plan-runner.test.ts
+++ b/src/executor/plan-runner.test.ts
@@ -75,6 +75,16 @@ describe("executePlan", () => {
     ])
   })
 
+  it("returns a virtual-to-real pane id map covering every emitted pane", async () => {
+    const executor = createMockExecutor()
+    const result = await executePlan({ emission: baseEmission, executor, windowMode: "new-window" })
+
+    expect(Object.fromEntries(result.paneMap)).toEqual({
+      "root.0": "%0",
+      "root.1": "%1",
+    })
+  })
+
   it("prefers structured split metadata over raw command arguments when provided", async () => {
     const executor = createMockExecutor()
     const emission: PlanEmission = {

--- a/src/executor/plan-runner.test.ts
+++ b/src/executor/plan-runner.test.ts
@@ -356,6 +356,77 @@ describe("executePlan", () => {
     }
   })
 
+  it("throws TMUX_COMMAND_FAILED when splitting a pane beside the sidebar fails", async () => {
+    const originalPane = process.env.TMUX_PANE
+    process.env.TMUX_PANE = "%9"
+
+    try {
+      const executor = {
+        execute: vi.fn(async (command: string | string[]) => {
+          const args = typeof command === "string" ? command.split(" ").slice(1) : command
+          if (args[0] === "list-panes") {
+            return "%9\t1"
+          }
+          if (args[0] === "split-window") {
+            throw new Error("tmux split-window failed")
+          }
+          return ""
+        }),
+        executeMany: vi.fn(async () => {}),
+        isDryRun: () => true,
+        logCommand: vi.fn(),
+      }
+
+      await expect(
+        executePlan({ emission: baseEmission, executor, windowMode: "current-window" }),
+      ).rejects.toMatchObject({
+        code: ErrorCodes.TMUX_COMMAND_FAILED,
+        path: "root.0",
+      })
+    } finally {
+      if (originalPane === undefined) {
+        delete process.env.TMUX_PANE
+      } else {
+        process.env.TMUX_PANE = originalPane
+      }
+    }
+  })
+
+  it("throws INVALID_PANE when the pane created beside the sidebar cannot be determined", async () => {
+    const originalPane = process.env.TMUX_PANE
+    process.env.TMUX_PANE = "%9"
+
+    try {
+      const executor = {
+        execute: vi.fn(async (command: string | string[]) => {
+          const args = typeof command === "string" ? command.split(" ").slice(1) : command
+          if (args[0] === "list-panes") {
+            // Always reports only the sidebar pane, simulating a split that never
+            // produced a new (or newly-visible) normal pane.
+            return "%9\t1"
+          }
+          return ""
+        }),
+        executeMany: vi.fn(async () => {}),
+        isDryRun: () => true,
+        logCommand: vi.fn(),
+      }
+
+      await expect(
+        executePlan({ emission: baseEmission, executor, windowMode: "current-window" }),
+      ).rejects.toMatchObject({
+        code: ErrorCodes.INVALID_PANE,
+        path: "root.0",
+      })
+    } finally {
+      if (originalPane === undefined) {
+        delete process.env.TMUX_PANE
+      } else {
+        process.env.TMUX_PANE = originalPane
+      }
+    }
+  })
+
   it("supports resolving ancestor and descendant virtual pane identifiers", async () => {
     const nestedEmission: PlanEmission = {
       steps: [

--- a/src/executor/plan-runner.ts
+++ b/src/executor/plan-runner.ts
@@ -59,7 +59,10 @@ export const executePlan = async ({
       isDryRun,
     })
 
-    const { sidebarPanes, normalPanes } = await classifyWindowPanes(executor, initialVirtualPaneId)
+    // Target the classification at the current pane's own window (via `-t
+    // currentPaneId`) rather than tmux's "active" window, so multi-window/multi-session
+    // setups always classify the window this invocation is actually running in.
+    const { sidebarPanes, normalPanes } = await classifyWindowPanes(executor, initialVirtualPaneId, currentPaneId)
     const sidebarPaneIds = new Set(sidebarPanes)
 
     let originPaneId: string
@@ -74,7 +77,6 @@ export const executePlan = async ({
           : await splitPaneBesideSidebar({
               executor,
               sidebarPaneId: currentPaneId,
-              existingPaneIds: new Set([...sidebarPanes, ...normalPanes]),
               contextPath: initialVirtualPaneId,
             })
     } else {
@@ -167,29 +169,30 @@ export const executePlan = async ({
  * pane. Only reached when the current window contains nothing but sidebar panes
  * (no normal pane to reuse). The split direction is fixed to a horizontal split
  * away from the sidebar (i.e. the new pane appears on the opposite side).
+ *
+ * Uses `-P -F "#{pane_id}"` to have tmux report the newly created pane id directly
+ * in the split-window output, rather than diffing a follow-up `list-panes` call
+ * against the pre-split pane set (which was fragile under concurrent pane changes).
  */
 const splitPaneBesideSidebar = async ({
   executor,
   sidebarPaneId,
-  existingPaneIds,
   contextPath,
 }: {
   readonly executor: CommandExecutor
   readonly sidebarPaneId: string
-  readonly existingPaneIds: ReadonlySet<string>
   readonly contextPath: string
 }): Promise<string> => {
-  await executeCommand(executor, ["split-window", "-h", "-t", sidebarPaneId], {
+  const command = ["split-window", "-h", "-P", "-F", "#{pane_id}", "-t", sidebarPaneId]
+  const output = await executeCommand(executor, command, {
     code: ErrorCodes.TMUX_COMMAND_FAILED,
     message: "Failed to split a pane beside the sidebar",
     path: contextPath,
-    details: { command: ["split-window", "-h", "-t", sidebarPaneId] },
+    details: { command },
   })
 
-  const after = await classifyWindowPanes(executor, contextPath)
-  const newPaneId = after.normalPanes.find((paneId) => !existingPaneIds.has(paneId))
-
-  if (newPaneId === undefined) {
+  const newPaneId = output.trim()
+  if (newPaneId.length === 0) {
     return raiseExecutionError(ErrorCodes.INVALID_PANE, {
       message: "Unable to determine the pane created beside the sidebar",
       path: contextPath,

--- a/src/executor/plan-runner.ts
+++ b/src/executor/plan-runner.ts
@@ -3,12 +3,12 @@ import type { ConfirmPaneClosure } from "../contracts"
 import type { CommandExecutor } from "../contracts"
 import { ErrorCodes } from "../utils/errors"
 import type { WindowMode } from "../models/types"
+import { classifyWindowPanes } from "./sidebar-detection"
 import {
   executeCommand,
   executeFocusStep,
   executeSplitStep,
   executeTerminalCommands,
-  listWindowPaneIds,
   normalizePaneId,
   raiseExecutionError,
   registerPane,
@@ -58,8 +58,29 @@ export const executePlan = async ({
       isDryRun,
     })
 
-    const panesInWindow = await listWindowPaneIds(executor, initialVirtualPaneId)
-    const panesToClose = panesInWindow.filter((paneId) => paneId !== currentPaneId)
+    const { sidebarPanes, normalPanes } = await classifyWindowPanes(executor, initialVirtualPaneId)
+    const sidebarPaneIds = new Set(sidebarPanes)
+
+    let originPaneId: string
+    if (sidebarPaneIds.has(currentPaneId)) {
+      // The resolved "current pane" is the protected sidebar pane itself. Rebuild the
+      // layout starting from the first non-sidebar pane instead, splitting a fresh one
+      // beside the sidebar when the window has no other panes to build on.
+      const [firstNormalPane] = normalPanes
+      originPaneId =
+        firstNormalPane !== undefined
+          ? firstNormalPane
+          : await splitPaneBesideSidebar({
+              executor,
+              sidebarPaneId: currentPaneId,
+              existingPaneIds: new Set([...sidebarPanes, ...normalPanes]),
+              contextPath: initialVirtualPaneId,
+            })
+    } else {
+      originPaneId = currentPaneId
+    }
+
+    const panesToClose = normalPanes.filter((paneId) => paneId !== originPaneId)
 
     if (panesToClose.length > 0) {
       let confirmed = true
@@ -75,15 +96,19 @@ export const executePlan = async ({
         })
       }
 
-      await executeCommand(executor, ["kill-pane", "-a", "-t", currentPaneId], {
-        code: ErrorCodes.TMUX_COMMAND_FAILED,
-        message: "Failed to close existing panes",
-        path: initialVirtualPaneId,
-        details: { command: ["kill-pane", "-a", "-t", currentPaneId] },
-      })
+      // `kill-pane -a` would also kill protected sidebar panes in real tmux, so close
+      // each non-sidebar pane individually instead of relying on the bulk flag.
+      for (const paneId of panesToClose) {
+        await executeCommand(executor, ["kill-pane", "-t", paneId], {
+          code: ErrorCodes.TMUX_COMMAND_FAILED,
+          message: "Failed to close existing panes",
+          path: initialVirtualPaneId,
+          details: { command: ["kill-pane", "-t", paneId] },
+        })
+      }
     }
 
-    initialPaneId = normalizePaneId(currentPaneId)
+    initialPaneId = normalizePaneId(originPaneId)
   } else {
     const newWindowCommand: string[] = ["new-window", "-P", "-F", "#{pane_id}"]
     if (typeof windowName === "string" && windowName.trim().length > 0) {
@@ -134,4 +159,41 @@ export const executePlan = async ({
   }
 
   return { executedSteps }
+}
+
+/**
+ * Splits a fresh pane beside the sidebar so it can be used as the layout's origin
+ * pane. Only reached when the current window contains nothing but sidebar panes
+ * (no normal pane to reuse). The split direction is fixed to a horizontal split
+ * away from the sidebar (i.e. the new pane appears on the opposite side).
+ */
+const splitPaneBesideSidebar = async ({
+  executor,
+  sidebarPaneId,
+  existingPaneIds,
+  contextPath,
+}: {
+  readonly executor: CommandExecutor
+  readonly sidebarPaneId: string
+  readonly existingPaneIds: ReadonlySet<string>
+  readonly contextPath: string
+}): Promise<string> => {
+  await executeCommand(executor, ["split-window", "-h", "-t", sidebarPaneId], {
+    code: ErrorCodes.TMUX_COMMAND_FAILED,
+    message: "Failed to split a pane beside the sidebar",
+    path: contextPath,
+    details: { command: ["split-window", "-h", "-t", sidebarPaneId] },
+  })
+
+  const after = await classifyWindowPanes(executor, contextPath)
+  const newPaneId = after.normalPanes.find((paneId) => !existingPaneIds.has(paneId))
+
+  if (newPaneId === undefined) {
+    return raiseExecutionError(ErrorCodes.INVALID_PANE, {
+      message: "Unable to determine the pane created beside the sidebar",
+      path: contextPath,
+    })
+  }
+
+  return newPaneId
 }

--- a/src/executor/plan-runner.ts
+++ b/src/executor/plan-runner.ts
@@ -27,6 +27,7 @@ type ExecutePlanInput = {
 
 type ExecutePlanSuccess = {
   readonly executedSteps: number
+  readonly paneMap: ReadonlyMap<string, string>
 }
 
 export const executePlan = async ({
@@ -158,7 +159,7 @@ export const executePlan = async ({
     })
   }
 
-  return { executedSteps }
+  return { executedSteps, paneMap }
 }
 
 /**

--- a/src/executor/sidebar-detection.test.ts
+++ b/src/executor/sidebar-detection.test.ts
@@ -38,6 +38,24 @@ describe("classifyWindowPanes", () => {
     expect(executor.getExecutedCommands()).toEqual([["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
   })
 
+  it("scopes list-panes to the target pane's window via -t when targetPaneId is provided", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0"])
+
+    await classifyWindowPanes(executor, "root.0", "%3")
+
+    expect(executor.getExecutedCommands()).toEqual([["list-panes", "-t", "%3", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
+  })
+
+  it("falls back to the untargeted list-panes query when targetPaneId is an empty string", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0"])
+
+    await classifyWindowPanes(executor, "root.0", "")
+
+    expect(executor.getExecutedCommands()).toEqual([["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
+  })
+
   it("throws a TMUX_COMMAND_FAILED CoreError when the executor rejects", async () => {
     const executor = {
       execute: async () => {

--- a/src/executor/sidebar-detection.test.ts
+++ b/src/executor/sidebar-detection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { classifyWindowPanes } from "./sidebar-detection"
+import { createMockExecutor } from "./mock-executor"
+import { ErrorCodes } from "../utils/errors"
+
+describe("classifyWindowPanes", () => {
+  it("splits panes into sidebar and normal groups based on the @vde_sidebar pane option", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0", "%1", "%2"])
+    executor.setMockProtectedPaneIds(["%1"])
+
+    const result = await classifyWindowPanes(executor, "root.0")
+
+    expect(result).toEqual({
+      sidebarPanes: ["%1"],
+      normalPanes: ["%0", "%2"],
+    })
+  })
+
+  it("returns all panes as normal when no pane has the sidebar option set", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0", "%1"])
+
+    const result = await classifyWindowPanes(executor, "root.0")
+
+    expect(result).toEqual({
+      sidebarPanes: [],
+      normalPanes: ["%0", "%1"],
+    })
+  })
+
+  it("issues a single list-panes query combining pane id and the sidebar option", async () => {
+    const executor = createMockExecutor()
+    executor.setMockPaneIds(["%0"])
+
+    await classifyWindowPanes(executor, "root.0")
+
+    expect(executor.getExecutedCommands()).toEqual([["list-panes", "-F", "#{pane_id}\t#{@vde_sidebar}"]])
+  })
+
+  it("throws a TMUX_COMMAND_FAILED CoreError when the executor rejects", async () => {
+    const executor = {
+      execute: async () => {
+        throw new Error("tmux failed")
+      },
+      executeMany: async () => {},
+      isDryRun: () => false,
+      logCommand: () => {},
+    }
+
+    await expect(classifyWindowPanes(executor, "root.0")).rejects.toMatchObject({
+      code: ErrorCodes.TMUX_COMMAND_FAILED,
+    })
+  })
+})

--- a/src/executor/sidebar-detection.ts
+++ b/src/executor/sidebar-detection.ts
@@ -20,8 +20,18 @@ export type ClassifyWindowPanesResult = {
 export const classifyWindowPanes = async (
   executor: CommandExecutor,
   contextPath: string,
+  targetPaneId?: string,
 ): Promise<ClassifyWindowPanesResult> => {
-  const output = await executeCommand(executor, ["list-panes", "-F", SIDEBAR_LIST_PANES_FORMAT], {
+  // `-t <pane-id>` scopes `list-panes` to the window that pane belongs to (tmux
+  // resolves a pane id target to its containing window), so passing the current
+  // pane id here guarantees the classification covers that pane's window even in
+  // multi-window/multi-session setups where the "active" window might differ.
+  const command =
+    typeof targetPaneId === "string" && targetPaneId.length > 0
+      ? ["list-panes", "-t", targetPaneId, "-F", SIDEBAR_LIST_PANES_FORMAT]
+      : ["list-panes", "-F", SIDEBAR_LIST_PANES_FORMAT]
+
+  const output = await executeCommand(executor, command, {
     code: ErrorCodes.TMUX_COMMAND_FAILED,
     message: "Failed to list tmux panes for sidebar detection",
     path: contextPath,

--- a/src/executor/sidebar-detection.ts
+++ b/src/executor/sidebar-detection.ts
@@ -1,0 +1,47 @@
+// Sidebar pane detection.
+//
+// vde-tmux-sidebar marks its own pane by setting the tmux pane user option
+// `@vde_sidebar` to `1`. Verified against real tmux 3.7b that a single
+// `list-panes -F "#{pane_id}\t#{@vde_sidebar}"` query expands both the pane
+// id and the pane user option value in one call: panes with the option set
+// return `1`, panes without it return an empty string. No per-pane
+// `show-options -pqv -t <pane> @vde_sidebar` fallback is needed.
+import type { CommandExecutor } from "../contracts"
+import { executeCommand } from "./plan-runner-helpers"
+import { ErrorCodes } from "../utils/errors"
+
+export const SIDEBAR_LIST_PANES_FORMAT = "#{pane_id}\t#{@vde_sidebar}"
+
+export type ClassifyWindowPanesResult = {
+  readonly sidebarPanes: string[]
+  readonly normalPanes: string[]
+}
+
+export const classifyWindowPanes = async (
+  executor: CommandExecutor,
+  contextPath: string,
+): Promise<ClassifyWindowPanesResult> => {
+  const output = await executeCommand(executor, ["list-panes", "-F", SIDEBAR_LIST_PANES_FORMAT], {
+    code: ErrorCodes.TMUX_COMMAND_FAILED,
+    message: "Failed to list tmux panes for sidebar detection",
+    path: contextPath,
+  })
+
+  const sidebarPanes: string[] = []
+  const normalPanes: string[] = []
+
+  for (const line of output.split("\n")) {
+    const [paneId, sidebarFlag] = line.split("\t")
+    if (typeof paneId !== "string" || paneId.trim().length === 0) {
+      continue
+    }
+
+    if (sidebarFlag?.trim() === "1") {
+      sidebarPanes.push(paneId.trim())
+    } else {
+      normalPanes.push(paneId.trim())
+    }
+  }
+
+  return { sidebarPanes, normalPanes }
+}

--- a/src/executor/terminal-backend.ts
+++ b/src/executor/terminal-backend.ts
@@ -15,6 +15,7 @@ export type ApplyPlanParameters = {
 export type ApplyPlanResult = {
   readonly executedSteps: number
   readonly focusPaneId?: string
+  readonly paneNameToRealId?: ReadonlyMap<string, string>
 }
 
 export type DryRunStep = {

--- a/src/executor/tmux-backend.test.ts
+++ b/src/executor/tmux-backend.test.ts
@@ -160,6 +160,54 @@ describe("createTmuxBackend", () => {
     expect(result.executedSteps).toBe(2)
   })
 
+  it("resolves the real focus pane id and pane name map from the plan runner's pane map", async () => {
+    const emission: PlanEmission = {
+      ...createEmission(),
+      terminals: [
+        { virtualPaneId: "root", command: undefined, cwd: undefined, env: undefined, focus: true, name: "main" },
+        {
+          virtualPaneId: "root.1",
+          command: undefined,
+          cwd: undefined,
+          env: undefined,
+          focus: false,
+          name: "sidebar",
+        },
+      ],
+    }
+    executePlanMock.mockResolvedValue({
+      executedSteps: 2,
+      paneMap: new Map([
+        ["root", "%0"],
+        ["root.1", "%1"],
+      ]),
+    })
+    const context = createContext()
+    getExecutorMock.mockReturnValue(context.executor)
+
+    const backend = createTmuxBackend(context)
+    const result = await backend.applyPlan({ emission, windowMode: "new-window" })
+
+    expect(result.focusPaneId).toBe("%0")
+    expect(Object.fromEntries(result.paneNameToRealId ?? new Map())).toEqual({
+      main: "%0",
+      sidebar: "%1",
+    })
+  })
+
+  it("falls back to an empty pane name map when the plan runner omits pane mapping", async () => {
+    const emission = createEmission()
+    executePlanMock.mockResolvedValue({ executedSteps: 2 })
+    const context = createContext()
+    getExecutorMock.mockReturnValue(context.executor)
+
+    const backend = createTmuxBackend(context)
+    const result = await backend.applyPlan({ emission, windowMode: "new-window" })
+
+    expect(result.focusPaneId).toBeUndefined()
+    expect(Object.fromEntries(result.paneNameToRealId ?? new Map())).toEqual({})
+  })
+
   it("provides dry-run steps with tmux command strings", () => {
     const emission = createEmission()
     const backend = createTmuxBackend(createContext())

--- a/src/executor/tmux-backend.test.ts
+++ b/src/executor/tmux-backend.test.ts
@@ -348,6 +348,14 @@ describe("createTmuxBackend", () => {
         summary: "split",
         command: "tmux split-window -h -t root -l 40",
       })
+      // list-panes must be scoped via -t to the current pane's own window (%5),
+      // not tmux's globally "active" window, so multi-window/multi-session setups
+      // resolve the origin pane correctly.
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        "tmux",
+        ["list-panes", "-t", "%5", "-F", "#{pane_id}\t#{@vde_sidebar}"],
+        expect.anything(),
+      )
     })
 
     it("falls back to <dynamic> when the sidebar has no normal pane to measure", () => {

--- a/src/executor/tmux-backend.test.ts
+++ b/src/executor/tmux-backend.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { CommandExecutor } from "../contracts"
 import type { PlanEmission } from "../core/emitter"
@@ -21,6 +21,10 @@ const { executePlanMock } = vi.hoisted(() => ({
   executePlanMock: vi.fn(),
 }))
 
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}))
+
 vi.mock("../backends/tmux/executor.ts", () => {
   return {
     createTmuxExecutor: vi.fn(() => ({
@@ -35,6 +39,12 @@ vi.mock("../backends/tmux/executor.ts", () => {
 vi.mock("./plan-runner.ts", () => {
   return {
     executePlan: executePlanMock,
+  }
+})
+
+vi.mock("node:child_process", () => {
+  return {
+    execFileSync: execFileSyncMock,
   }
 })
 
@@ -97,6 +107,13 @@ describe("createTmuxBackend", () => {
     executeMock.mockReset()
     getCommandStringMock.mockImplementation((args: string[]) => `tmux ${args.join(" ")}`)
     executeMock.mockResolvedValue("tmux 3.4")
+    execFileSyncMock.mockReset()
+    // Default: behave as if no real tmux session backs process.env.TMUX_PANE, so
+    // pane-size resolution silently falls back to undefined unless a test opts in
+    // with its own implementation.
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("tmux not available")
+    })
   })
 
   const createContext = (overrides: Partial<TmuxTerminalBackendContext> = {}): TmuxTerminalBackendContext => ({
@@ -208,6 +225,126 @@ describe("createTmuxBackend", () => {
         process.env.TMUX_PANE = originalTMUXPane
       }
     }
+  })
+
+  const withDynamicCellsEmission = (): PlanEmission => {
+    const baseEmission = createEmission()
+    const [splitStep, focusStep] = baseEmission.steps
+    if (splitStep === undefined || focusStep === undefined) {
+      throw new Error("expected split and focus steps")
+    }
+
+    return {
+      ...baseEmission,
+      steps: [
+        {
+          ...splitStep,
+          splitSizing: {
+            mode: "dynamic-cells",
+            target: { kind: "fixed-cells", cells: 80 },
+            remainingFixedCells: 0,
+            remainingWeight: 1,
+            remainingWeightPaneCount: 1,
+          },
+          percentage: undefined,
+        },
+        focusStep,
+      ],
+    }
+  }
+
+  describe("dry-run pane sizing when the current pane is the protected sidebar", () => {
+    let originalTMUX: string | undefined
+    let originalTMUXPane: string | undefined
+
+    beforeEach(() => {
+      originalTMUX = process.env.TMUX
+      originalTMUXPane = process.env.TMUX_PANE
+      process.env.TMUX = "test-socket,123,0"
+      process.env.TMUX_PANE = "%5"
+    })
+
+    afterEach(() => {
+      if (originalTMUX === undefined) {
+        delete process.env.TMUX
+      } else {
+        process.env.TMUX = originalTMUX
+      }
+
+      if (originalTMUXPane === undefined) {
+        delete process.env.TMUX_PANE
+      } else {
+        process.env.TMUX_PANE = originalTMUXPane
+      }
+    })
+
+    it("uses the resolved origin pane's size when the current pane is the sidebar", () => {
+      execFileSyncMock.mockImplementation((_command: string, args: string[]) => {
+        if (args[3] === "%5" && args[4] === "#{pane_width} #{pane_height} #{@vde_sidebar}") {
+          return "10 20 1"
+        }
+        if (args[0] === "list-panes") {
+          return "%5\t1\n%6\t\n"
+        }
+        if (args[3] === "%6" && args[4] === "#{pane_width} #{pane_height}") {
+          return "120 40"
+        }
+        throw new Error(`unexpected tmux call: ${args.join(" ")}`)
+      })
+
+      const backend = createTmuxBackend(createContext())
+      const steps = backend.getDryRunSteps(withDynamicCellsEmission())
+
+      expect(steps[0]).toEqual({
+        backend: "tmux",
+        summary: "split",
+        command: "tmux split-window -h -t root -l 40",
+      })
+    })
+
+    it("falls back to <dynamic> when the sidebar has no normal pane to measure", () => {
+      execFileSyncMock.mockImplementation((_command: string, args: string[]) => {
+        if (args[3] === "%5" && args[4] === "#{pane_width} #{pane_height} #{@vde_sidebar}") {
+          return "10 20 1"
+        }
+        if (args[0] === "list-panes") {
+          return "%5\t1"
+        }
+        throw new Error(`unexpected tmux call: ${args.join(" ")}`)
+      })
+
+      const backend = createTmuxBackend(createContext())
+      const steps = backend.getDryRunSteps(withDynamicCellsEmission())
+
+      expect(steps[0]).toEqual({
+        backend: "tmux",
+        summary: "split",
+        command: "tmux split-window -h -t root -l <dynamic>",
+      })
+    })
+
+    it("uses the current pane's own size directly when it is not the sidebar (no regression)", () => {
+      execFileSyncMock.mockImplementation((_command: string, args: string[]) => {
+        if (args[3] === "%5" && args[4] === "#{pane_width} #{pane_height} #{@vde_sidebar}") {
+          return "120 40"
+        }
+        throw new Error(`unexpected tmux call: ${args.join(" ")}`)
+      })
+
+      const backend = createTmuxBackend(createContext())
+      const steps = backend.getDryRunSteps(withDynamicCellsEmission())
+
+      expect(steps[0]).toEqual({
+        backend: "tmux",
+        summary: "split",
+        command: "tmux split-window -h -t root -l 40",
+      })
+      expect(execFileSyncMock).not.toHaveBeenCalledWith(
+        "tmux",
+        expect.arrayContaining(["list-panes"]),
+        expect.anything(),
+      )
+    })
   })
 
   it("throws MISSING_TARGET when dry-run split step omits target metadata", () => {

--- a/src/executor/wezterm-backend.test.ts
+++ b/src/executor/wezterm-backend.test.ts
@@ -360,6 +360,25 @@ describe("createWeztermBackend", () => {
     expect(result.focusPaneId).toBe("42")
   })
 
+  it("resolves the pane name map from the final virtual-to-real pane mapping", async () => {
+    queueListResponses(
+      makeList([{ windowId: "7", panes: [{ paneId: "10", active: true }] }]),
+      makeList([{ windowId: "7", panes: [{ paneId: "10", active: true }, { paneId: "42" }] }]),
+    )
+    runMock.mockResolvedValueOnce("42 7\n")
+
+    const backend = createWeztermBackend(createContext())
+    const emission: PlanEmission = {
+      ...minimalEmission(),
+      terminals: [
+        { virtualPaneId: "root", command: undefined, cwd: undefined, env: undefined, focus: true, name: "main" },
+      ],
+    }
+    const result = await backend.applyPlan({ emission, windowMode: "new-window" })
+
+    expect(Object.fromEntries(result.paneNameToRealId ?? new Map())).toEqual({ main: "42" })
+  })
+
   it("targets the workspace of the current pane when multiple workspaces exist", async () => {
     queueListResponses(
       makeList([

--- a/src/models/schema.test.ts
+++ b/src/models/schema.test.ts
@@ -199,6 +199,50 @@ describe("Zod schema validation", () => {
 
       expect(result.success).toBe(false)
     })
+
+    it("accepts hooks.afterApply in preset definition", () => {
+      const result = PresetSchema.safeParse({
+        name: "Sidebar Preset",
+        hooks: {
+          afterApply: "vde-tmux-sidebar open {{pane_id:sidebar}}",
+        },
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it("validates preset without hooks field", () => {
+      const result = PresetSchema.safeParse({
+        name: "No Hooks Preset",
+      })
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.hooks).toBeUndefined()
+      }
+    })
+
+    it("rejects empty string for hooks.afterApply", () => {
+      const result = validatePreset({
+        name: "Invalid Hooks Preset",
+        hooks: {
+          afterApply: "",
+        },
+      })
+
+      expect(result.success).toBe(false)
+    })
+
+    it("rejects unknown keys inside hooks", () => {
+      const result = validatePreset({
+        name: "Invalid Hooks Preset",
+        hooks: {
+          beforeApply: "echo not-supported",
+        },
+      })
+
+      expect(result.success).toBe(false)
+    })
   })
 
   describe("ConfigSchema", () => {

--- a/src/models/schema.ts
+++ b/src/models/schema.ts
@@ -13,6 +13,12 @@ const SelectorFzfSchema = z
   })
   .strict()
 
+const HooksSchema = z
+  .object({
+    afterApply: z.string().min(1).optional(),
+  })
+  .strict()
+
 const SelectorDefaultsSchema = z
   .object({
     ui: SelectUiModeSchema.optional(),
@@ -99,6 +105,7 @@ export const PresetSchema = z.object({
   command: z.string().optional(),
   windowMode: WindowModeSchema.optional(),
   backend: TerminalBackendSchema.optional(),
+  hooks: HooksSchema.optional(),
 })
 
 // Config schema definition


### PR DESCRIPTION
## Summary
- current-window モードで pane user option `@vde_sidebar = 1` のペインを保護: kill 対象から除外し(`kill-pane -a` を個別 `kill-pane -t` に置換)、現在ペインがサイドバーの場合は非サイドバーペイン(無ければサイドバー隣に split したペイン)を起点に差し替え
- dry-run の基準サイズ取得を補正し、現在ペインがサイドバーでも起点ペインの実測サイズで手順を表示
- プリセット適用成功後に一度だけホストコマンドを実行する汎用 `hooks.afterApply` を追加(テンプレートトークン対応、失敗は警告のみで exit code 不変、dry-run では計画表示のみ)。vde-tmux-sidebar の冪等 open との連携用
- MockExecutor に保護ペインのシミュレーションを追加、README に保護挙動と hooks を記載

## Verification
- pnpm run ci (433 tests / typecheck / format green。lint の tsdown.config.ts parsing error は main でも再現する既存問題)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preset hooks, including an `afterApply` command that runs after a successful apply.
  * Dry runs now show planned hook commands alongside other planned actions.
  * Added sidebar-aware window handling so protected panes are preserved during layout changes.

* **Bug Fixes**
  * Improved pane mapping so focus and named panes resolve more reliably after apply.
  * Dry-run pane sizing now behaves correctly when the current pane is a protected sidebar.

* **Documentation**
  * Updated the README with hook usage, runtime behavior, and sidebar protection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->