### PR TITLE
feat: add window_id template token for hooks.afterApply

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ You can reference dynamically-assigned pane IDs within pane commands using templ
 - **`{{this_pane}}`** - References the current pane receiving the command
 - **`{{focus_pane}}`** - References the pane that will receive focus
 - **`{{pane_id:<name>}}`** - References a specific pane by its name
-- **`{{window_id}}`** - References the real window ID the layout was applied into (e.g. tmux's `@5`). Only resolved in `hooks.afterApply` (see [Hooks](#hooks)); it is not resolved in pane `command`.
+- **`{{window_id}}`** - References the real window ID the layout was applied into (e.g. tmux's `@5`). Only resolved in `hooks.afterApply` (see [Hooks](#hooks)) — using it in a pane `command` raises a template token error rather than resolving, the same as referencing an unknown `{{pane_id:<name>}}`.
 
 Example:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ You can reference dynamically-assigned pane IDs within pane commands using templ
 - **`{{this_pane}}`** - References the current pane receiving the command
 - **`{{focus_pane}}`** - References the pane that will receive focus
 - **`{{pane_id:<name>}}`** - References a specific pane by its name
+- **`{{window_id}}`** - References the real window ID the layout was applied into (e.g. tmux's `@5`). Only resolved in `hooks.afterApply` (see [Hooks](#hooks)); it is not resolved in pane `command`.
 
 Example:
 ```yaml
@@ -213,6 +214,14 @@ presets:
 - If the command fails, or if a template token inside it cannot be resolved, vde-layout logs a warning and the preset apply is still reported as successful (exit code is unaffected).
 - The command is killed and treated as a failure (logged as a warning) if it runs for longer than 30 seconds.
 - Template tokens are supported, but `{{pane_id:<name>}}` only resolves against the pane names created by *this apply's* own `layout` — it cannot address an existing external pane such as a sidebar. This is especially easy to get wrong in `current-window` mode: the reused current pane is bound to the layout tree's first pane name, so a hook that tries `{{pane_id:sidebar}}` for a preset pane named `sidebar` would silently resolve to the current pane, not the real sidebar. Because the hook doesn't run "in" any specific pane, `{{this_pane}}` and `{{focus_pane}}` both resolve to the pane that ended up focused after the apply.
+- `{{window_id}}` resolves to the real window ID the layout was applied into (tmux's `@5`-style ID, or wezterm's window ID). This is the recommended way to hand off to an external tool such as [vde-tmux-sidebar](https://github.com/yuki-yano/vde-tmux-sidebar) that needs to target the applied window — tmux's `-t` does not expand formats, so vde-layout resolves it to a literal before running the hook:
+
+  ```yaml
+  hooks:
+    afterApply: "command -v vde-tmux-sidebar >/dev/null 2>&1 && vde-tmux-sidebar layout-applied --window '{{window_id}}' || true"
+  ```
+
+  If `{{window_id}}` is used but the window ID could not be resolved, the hook is skipped (logged as a warning) rather than run with a blank value.
 
 ### Ephemeral Panes
 Ephemeral panes automatically close after their command completes. This is useful for one-time tasks like builds, tests, or initialization scripts.

--- a/src/backends/tmux/backend.ts
+++ b/src/backends/tmux/backend.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process"
 import { type PaneDimensions, updatePaneSizes } from "../pane-tracking"
-import { createTmuxExecutor } from "./executor"
+import { createTmuxExecutor, type TmuxExecutor } from "./executor"
 import type { CommandStep, PlanEmission } from "../../core/emitter"
 import { isCoreError } from "../../core/errors"
 import { executePlan } from "../../executor/plan-runner"
@@ -73,11 +73,13 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
     // name/focus without knowing tmux's virtual ids. Tests may stub executePlan
     // without a paneMap, so fall back to an empty one rather than throwing.
     const paneMap = executionResult.paneMap ?? new Map<string, string>()
+    const focusPaneId = paneMap.get(emission.summary.focusPaneId)
 
     return {
       executedSteps: executionResult.executedSteps,
-      focusPaneId: paneMap.get(emission.summary.focusPaneId),
+      focusPaneId,
       paneNameToRealId: buildNameToRealIdMap(emission.terminals, paneMap),
+      windowId: await resolveTmuxWindowId({ tmuxExecutor, focusPaneId }),
     }
   }
 
@@ -85,6 +87,32 @@ export const createTmuxBackend = (context: TmuxTerminalBackendContext): Terminal
     verifyEnvironment,
     applyPlan,
     getDryRunSteps: buildDryRunSteps,
+  }
+}
+
+// Resolves the real tmux window id (e.g. "@5") the layout was applied into, so
+// callers such as hooks.afterApply can pass it to external tools via {{window_id}}.
+// tmux's `-t` does not expand formats, so this literal must be resolved here rather
+// than left for the consuming command to figure out. Issued once, after the plan has
+// finished applying; any failure (e.g. the pane has since gone away) is swallowed so
+// it never affects the outcome of applyPlan itself.
+const resolveTmuxWindowId = async ({
+  tmuxExecutor,
+  focusPaneId,
+}: {
+  readonly tmuxExecutor: TmuxExecutor
+  readonly focusPaneId: string | undefined
+}): Promise<string | undefined> => {
+  if (focusPaneId === undefined) {
+    return undefined
+  }
+
+  try {
+    const output = await tmuxExecutor.execute(["display-message", "-p", "-t", focusPaneId, "#{window_id}"])
+    const trimmed = output.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  } catch {
+    return undefined
   }
 }
 

--- a/src/backends/wezterm/backend.ts
+++ b/src/backends/wezterm/backend.ts
@@ -153,6 +153,7 @@ export const createWeztermBackend = (context: WeztermTerminalBackendContext): Te
       executedSteps,
       focusPaneId,
       paneNameToRealId: buildNameToRealIdMap(emission.terminals, paneMap),
+      windowId,
     }
   }
 

--- a/src/cli/after-apply-hook.test.ts
+++ b/src/cli/after-apply-hook.test.ts
@@ -79,6 +79,39 @@ describe("runAfterApplyHook", () => {
     expect(runHostCommand).toHaveBeenCalledWith("notify-focus %1 %1", { cwd: "/workspace" })
   })
 
+  it("resolves {{window_id}} to the applied window id", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "vde-tmux-sidebar layout-applied --window '{{window_id}}'",
+      context: { cwd: "/workspace", focusPaneId: "%1", windowId: "@5" },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).toHaveBeenCalledWith("vde-tmux-sidebar layout-applied --window '@5'", {
+      cwd: "/workspace",
+    })
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it("warns and skips execution when {{window_id}} is used but no window id is available", async () => {
+    const logger = createMockLogger()
+    const runHostCommand = vi.fn(async () => {})
+
+    await runAfterApplyHook({
+      hookCommand: "vde-tmux-sidebar layout-applied --window '{{window_id}}'",
+      context: { cwd: "/workspace", focusPaneId: "%1" },
+      logger,
+      runHostCommand,
+    })
+
+    expect(runHostCommand).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("window id"))
+  })
+
   it("warns and skips execution when a template token cannot be resolved", async () => {
     const logger = createMockLogger()
     const runHostCommand = vi.fn(async () => {})

--- a/src/cli/after-apply-hook.ts
+++ b/src/cli/after-apply-hook.ts
@@ -13,6 +13,7 @@ export type AfterApplyHookContext = {
   readonly cwd: string
   readonly focusPaneId?: string
   readonly paneNameToRealId?: ReadonlyMap<string, string>
+  readonly windowId?: string
 }
 
 type RunAfterApplyHookInput = {
@@ -25,6 +26,11 @@ type RunAfterApplyHookInput = {
 // Matches the {{this_pane}}/{{focus_pane}} tokens that this module resolves to
 // context.focusPaneId (see the comment below on why they share one value).
 const FOCUS_PANE_TOKEN_PATTERN = /\{\{(?:this_pane|focus_pane)\}\}/
+
+// Matches {{window_id}}, resolved to context.windowId (the real tmux/wezterm window
+// id the layout was applied into, e.g. tmux's "@5"). tmux's `-t` does not expand
+// formats, so tools like vde-tmux-sidebar need this literal passed in.
+const WINDOW_ID_TOKEN_PATTERN = /\{\{window_id\}\}/
 
 /**
  * Runs the `hooks.afterApply` preset command once, after a preset has been applied
@@ -54,6 +60,16 @@ export const runAfterApplyHook = async ({
     return
   }
 
+  // {{window_id}} resolves to context.windowId, but replaceTemplateTokens substitutes
+  // it verbatim even when given an empty string (see the focus pane id comment above
+  // for why the same guard pattern applies here).
+  if (context.windowId === undefined && WINDOW_ID_TOKEN_PATTERN.test(hookCommand)) {
+    logger.warn(
+      "hooks.afterApply skipped: failed to resolve template tokens ({{window_id}} requires a window id, but none was available)",
+    )
+    return
+  }
+
   let resolvedCommand: string
   try {
     resolvedCommand = replaceTemplateTokens({
@@ -66,6 +82,7 @@ export const runAfterApplyHook = async ({
       currentPaneRealId: context.focusPaneId ?? "",
       focusPaneRealId: context.focusPaneId ?? "",
       nameToRealIdMap: context.paneNameToRealId ?? new Map<string, string>(),
+      windowId: context.windowId,
     })
   } catch (error) {
     const reason = error instanceof TemplateTokenError ? error.message : String(error)

--- a/src/cli/after-apply-hook.ts
+++ b/src/cli/after-apply-hook.ts
@@ -60,9 +60,10 @@ export const runAfterApplyHook = async ({
     return
   }
 
-  // {{window_id}} resolves to context.windowId, but replaceTemplateTokens substitutes
-  // it verbatim even when given an empty string (see the focus pane id comment above
-  // for why the same guard pattern applies here).
+  // {{window_id}} resolves to context.windowId. replaceTemplateTokens already throws
+  // TemplateTokenError for this case (caught below), but that generic message doesn't
+  // mention "window id" specifically; this guard produces a clearer warning up front
+  // and doubles as defense-in-depth if that throw behavior ever changes.
   if (context.windowId === undefined && WINDOW_ID_TOKEN_PATTERN.test(hookCommand)) {
     logger.warn(
       "hooks.afterApply skipped: failed to resolve template tokens ({{window_id}} requires a window id, but none was available)",

--- a/src/cli/preset-execution.test.ts
+++ b/src/cli/preset-execution.test.ts
@@ -274,6 +274,47 @@ describe("executePreset", () => {
     })
   })
 
+  it("passes the resolved window id from applyPlan through to hooks.afterApply", async () => {
+    const logger = createMockLogger()
+    const presetManager = createMockPresetManager(basePreset)
+    const core = createMockCore(baseEmission, {
+      hooks: { afterApply: "vde-tmux-sidebar layout-applied --window '{{window_id}}'" },
+    })
+    const executor = createMockExecutor()
+    const backend: TerminalBackend = {
+      verifyEnvironment: vi.fn(async () => {}),
+      applyPlan: vi.fn(async () => ({ executedSteps: 2, focusPaneId: "%0", windowId: "@5" })),
+      getDryRunSteps: vi.fn(() => []),
+    }
+    createTerminalBackendMock.mockReturnValue(backend)
+
+    const exitCode = await executePreset({
+      presetName: "dev",
+      options: {
+        verbose: false,
+        dryRun: false,
+        currentWindow: false,
+        newWindow: true,
+      },
+      presetManager,
+      createCommandExecutor: vi.fn(() => executor),
+      core,
+      logger,
+      handleError: vi.fn(() => 1),
+      handlePipelineFailure: vi.fn(() => 1),
+      output: vi.fn(),
+      cwd: "/workspace",
+      env: {},
+    })
+
+    expect(exitCode).toBe(0)
+    expect(runAfterApplyHookMock).toHaveBeenCalledWith({
+      hookCommand: "vde-tmux-sidebar layout-applied --window '{{window_id}}'",
+      context: { cwd: "/workspace", focusPaneId: "%0", paneNameToRealId: undefined, windowId: "@5" },
+      logger,
+    })
+  })
+
   it("skips hooks.afterApply during dry-run and renders it as a planned step instead", async () => {
     const logger = createMockLogger()
     const presetManager = createMockPresetManager(basePreset)

--- a/src/cli/preset-execution.ts
+++ b/src/cli/preset-execution.ts
@@ -140,6 +140,7 @@ export const executePreset = async ({
               cwd,
               focusPaneId: executionResult.focusPaneId,
               paneNameToRealId: executionResult.paneNameToRealId,
+              windowId: executionResult.windowId,
             },
             logger,
           })

--- a/src/executor/terminal-backend.ts
+++ b/src/executor/terminal-backend.ts
@@ -16,6 +16,7 @@ export type ApplyPlanResult = {
   readonly executedSteps: number
   readonly focusPaneId?: string
   readonly paneNameToRealId?: ReadonlyMap<string, string>
+  readonly windowId?: string
 }
 
 export type DryRunStep = {

--- a/src/executor/terminal-command-preparation.test.ts
+++ b/src/executor/terminal-command-preparation.test.ts
@@ -226,6 +226,33 @@ describe("prepareTerminalCommands", () => {
     ).toThrow("root.0:pane_id")
   })
 
+  it("delegates {{window_id}} in a pane command to the template token error mapper instead of silently blanking it", () => {
+    const terminals: ReadonlyArray<EmittedTerminal> = [
+      {
+        virtualPaneId: "root.0",
+        cwd: undefined,
+        env: undefined,
+        command: "echo {{window_id}}",
+        focus: true,
+        name: "main",
+      },
+    ]
+
+    expect(() =>
+      prepareTerminalCommands({
+        terminals,
+        focusPaneVirtualId: "root.0",
+        resolveRealPaneId: createResolvePaneId({
+          "root.0": "%0",
+        }),
+        onTemplateTokenError: ({ terminal, error }): never => {
+          const typedError = error as TemplateTokenError
+          throw new Error(`${terminal.virtualPaneId}:${typedError.tokenType}`)
+        },
+      }),
+    ).toThrow("root.0:window_id")
+  })
+
   it("throws for invalid environment variable names", () => {
     const terminals: ReadonlyArray<EmittedTerminal> = [
       {

--- a/src/executor/tmux-backend.test.ts
+++ b/src/executor/tmux-backend.test.ts
@@ -210,6 +210,7 @@ describe("createTmuxBackend", () => {
 
     expect(result.windowId).toBe("@5")
     expect(executeMock).toHaveBeenCalledWith(["display-message", "-p", "-t", "%0", "#{window_id}"])
+    expect(executeMock).toHaveBeenCalledTimes(1)
   })
 
   it("falls back to an undefined window id when the display-message query fails", async () => {

--- a/src/executor/tmux-backend.test.ts
+++ b/src/executor/tmux-backend.test.ts
@@ -195,6 +195,54 @@ describe("createTmuxBackend", () => {
     })
   })
 
+  it("resolves the real window id via a single display-message query after apply", async () => {
+    const emission = createEmission()
+    executePlanMock.mockResolvedValue({
+      executedSteps: 2,
+      paneMap: new Map([["root", "%0"]]),
+    })
+    const context = createContext()
+    getExecutorMock.mockReturnValue(context.executor)
+    executeMock.mockResolvedValue("@5\n")
+
+    const backend = createTmuxBackend(context)
+    const result = await backend.applyPlan({ emission, windowMode: "new-window" })
+
+    expect(result.windowId).toBe("@5")
+    expect(executeMock).toHaveBeenCalledWith(["display-message", "-p", "-t", "%0", "#{window_id}"])
+  })
+
+  it("falls back to an undefined window id when the display-message query fails", async () => {
+    const emission = createEmission()
+    executePlanMock.mockResolvedValue({
+      executedSteps: 2,
+      paneMap: new Map([["root", "%0"]]),
+    })
+    const context = createContext()
+    getExecutorMock.mockReturnValue(context.executor)
+    executeMock.mockRejectedValue(new Error("tmux display-message failed"))
+
+    const backend = createTmuxBackend(context)
+    const result = await backend.applyPlan({ emission, windowMode: "new-window" })
+
+    expect(result.windowId).toBeUndefined()
+    expect(result.executedSteps).toBe(2)
+    expect(result.focusPaneId).toBe("%0")
+  })
+
+  it("skips the window id query when no real focus pane id was resolved", async () => {
+    const emission = createEmission()
+    executePlanMock.mockResolvedValue({ executedSteps: 2 })
+    const context = createContext()
+    getExecutorMock.mockReturnValue(context.executor)
+
+    const backend = createTmuxBackend(context)
+    const result = await backend.applyPlan({ emission, windowMode: "new-window" })
+
+    expect(result.windowId).toBeUndefined()
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
   it("falls back to an empty pane name map when the plan runner omits pane mapping", async () => {
     const emission = createEmission()
     executePlanMock.mockResolvedValue({ executedSteps: 2 })

--- a/src/executor/wezterm-backend.test.ts
+++ b/src/executor/wezterm-backend.test.ts
@@ -358,6 +358,7 @@ describe("createWeztermBackend", () => {
       expect.objectContaining({ message: "Failed to spawn wezterm tab" }),
     )
     expect(result.focusPaneId).toBe("42")
+    expect(result.windowId).toBe("7")
   })
 
   it("resolves the pane name map from the final virtual-to-real pane mapping", async () => {

--- a/src/utils/template-tokens.test.ts
+++ b/src/utils/template-tokens.test.ts
@@ -72,14 +72,29 @@ describe("replaceTemplateTokens", () => {
     expect(result).toBe("vde-tmux-sidebar layout-applied --window '@5'")
   })
 
-  it("should replace {{window_id}} with an empty string when windowId is not provided", () => {
-    const result = replaceTemplateTokens({
-      command: "notify --window {{window_id}}",
-      currentPaneRealId: "%1",
-      focusPaneRealId: "%2",
-      nameToRealIdMap: new Map(),
-    })
-    expect(result).toBe("notify --window ")
+  it("should throw TemplateTokenError when {{window_id}} is used but windowId is not provided", () => {
+    expect(() => {
+      replaceTemplateTokens({
+        command: "notify --window {{window_id}}",
+        currentPaneRealId: "%1",
+        focusPaneRealId: "%2",
+        nameToRealIdMap: new Map(),
+      })
+    }).toThrow(TemplateTokenError)
+
+    try {
+      replaceTemplateTokens({
+        command: "notify --window {{window_id}}",
+        currentPaneRealId: "%1",
+        focusPaneRealId: "%2",
+        nameToRealIdMap: new Map(),
+      })
+    } catch (error) {
+      expect(error).toBeInstanceOf(TemplateTokenError)
+      if (error instanceof TemplateTokenError) {
+        expect(error.tokenType).toBe("window_id")
+      }
+    }
   })
 
   it("should handle commands with no template tokens", () => {

--- a/src/utils/template-tokens.test.ts
+++ b/src/utils/template-tokens.test.ts
@@ -61,6 +61,27 @@ describe("replaceTemplateTokens", () => {
     expect(result).toBe("%1 and %1 again")
   })
 
+  it("should replace {{window_id}} with the provided window ID", () => {
+    const result = replaceTemplateTokens({
+      command: "vde-tmux-sidebar layout-applied --window '{{window_id}}'",
+      currentPaneRealId: "%1",
+      focusPaneRealId: "%2",
+      nameToRealIdMap: new Map(),
+      windowId: "@5",
+    })
+    expect(result).toBe("vde-tmux-sidebar layout-applied --window '@5'")
+  })
+
+  it("should replace {{window_id}} with an empty string when windowId is not provided", () => {
+    const result = replaceTemplateTokens({
+      command: "notify --window {{window_id}}",
+      currentPaneRealId: "%1",
+      focusPaneRealId: "%2",
+      nameToRealIdMap: new Map(),
+    })
+    expect(result).toBe("notify --window ")
+  })
+
   it("should handle commands with no template tokens", () => {
     const result = replaceTemplateTokens({
       command: "echo 'Hello, world!'",

--- a/src/utils/template-tokens.ts
+++ b/src/utils/template-tokens.ts
@@ -5,6 +5,10 @@ import type { EmittedTerminal } from "../core/emitter"
  * - {{pane_id:<name>}} - resolves to a specific pane's ID by name
  * - {{this_pane}} - references the current pane receiving the command
  * - {{focus_pane}} - references the intended focus pane
+ * - {{window_id}} - references the real window ID the layout was applied into
+ *   (e.g. tmux's `@5`). Only resolved by callers that supply `windowId`
+ *   (currently hooks.afterApply); other callers omit it and the token
+ *   substitutes to an empty string.
  */
 
 type ReplaceTemplateTokensInput = {
@@ -12,6 +16,7 @@ type ReplaceTemplateTokensInput = {
   readonly currentPaneRealId: string
   readonly focusPaneRealId: string
   readonly nameToRealIdMap: ReadonlyMap<string, string>
+  readonly windowId?: string
 }
 
 export type TemplateTokenError = Error & {
@@ -60,10 +65,11 @@ export const replaceTemplateTokens = ({
   currentPaneRealId,
   focusPaneRealId,
   nameToRealIdMap,
+  windowId,
 }: ReplaceTemplateTokensInput): string => {
   // Single-pass regex that matches all token types
   // This prevents nested token issues by replacing everything in one pass
-  const tokenPattern = /\{\{(this_pane|focus_pane|pane_id:([^}]+))\}\}/g
+  const tokenPattern = /\{\{(this_pane|focus_pane|window_id|pane_id:([^}]+))\}\}/g
 
   return command.replace(tokenPattern, (match, tokenContent: string, paneName?: string) => {
     if (tokenContent === "this_pane") {
@@ -72,6 +78,10 @@ export const replaceTemplateTokens = ({
 
     if (tokenContent === "focus_pane") {
       return focusPaneRealId
+    }
+
+    if (tokenContent === "window_id") {
+      return windowId ?? ""
     }
 
     // Must be pane_id:<name> token

--- a/src/utils/template-tokens.ts
+++ b/src/utils/template-tokens.ts
@@ -7,8 +7,9 @@ import type { EmittedTerminal } from "../core/emitter"
  * - {{focus_pane}} - references the intended focus pane
  * - {{window_id}} - references the real window ID the layout was applied into
  *   (e.g. tmux's `@5`). Only resolved by callers that supply `windowId`
- *   (currently hooks.afterApply); other callers omit it and the token
- *   substitutes to an empty string.
+ *   (currently hooks.afterApply); callers that omit it - e.g. pane
+ *   `command:` preparation - get a TemplateTokenError if the token is used,
+ *   the same as an unresolved {{pane_id:<name>}}.
  */
 
 type ReplaceTemplateTokensInput = {
@@ -58,7 +59,8 @@ export const TemplateTokenError = TemplateTokenErrorImpl as TemplateTokenErrorCo
  *
  * @param input - Object containing the command and pane ID mappings
  * @returns The command string with all template tokens replaced
- * @throws TemplateTokenError if a referenced pane name is not found in the mapping
+ * @throws TemplateTokenError if a referenced pane name is not found in the mapping,
+ *   or if {{window_id}} is used but no `windowId` was supplied
  */
 export const replaceTemplateTokens = ({
   command,
@@ -81,7 +83,13 @@ export const replaceTemplateTokens = ({
     }
 
     if (tokenContent === "window_id") {
-      return windowId ?? ""
+      if (windowId === undefined) {
+        throw new TemplateTokenError(
+          "Window ID is not available. {{window_id}} can only be resolved in hooks.afterApply.",
+          "window_id",
+        )
+      }
+      return windowId
     }
 
     // Must be pane_id:<name> token


### PR DESCRIPTION
## Summary
- `hooks.afterApply` のコマンド内で `{{window_id}}` を適用先 window の実 ID(tmux は `@N` 形式)に解決するテンプレートトークンを追加
- tmux backend は apply 成功後に `display-message -p -t <focus_pane> '#{window_id}'` を1回発行して解決(失敗時は undefined に落とし apply は成功のまま)。wezterm は既存の window 識別子を流用
- 未解決時は警告してスキップ(hook)/ TemplateTokenError(pane command)で、空文字が黙って差し込まれる経路を排除。README に vde-tmux-sidebar 連携例を記載

## Verification
- pnpm run ci (444 tests / typecheck / lint / format green)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `{{window_id}}` template token in after-apply hook commands.
  * Hook commands can now receive the real window ID when it’s available.

* **Bug Fixes**
  * Commands using `{{window_id}}` now fail safely instead of running with a blank value.
  * If the window ID can’t be resolved, the hook is skipped with a warning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->